### PR TITLE
[WBS-185]Feature/add token logic

### DIFF
--- a/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
@@ -25,13 +25,13 @@ object ApiModule {
 
     @Singleton
     @Provides
-    fun provideExampleApi(retrofit: Retrofit): ExampleApi {
+    fun provideExampleApi(@NormalRetrofit retrofit: Retrofit): ExampleApi {
         return retrofit.create(ExampleApi::class.java)
     }
 
     @Singleton
     @Provides
-    fun provideFeedApi(retrofit: Retrofit): FeedApi {
+    fun provideFeedApi(@AuthRetrofit retrofit: Retrofit): FeedApi {
         return retrofit.create(FeedApi::class.java)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
@@ -31,7 +31,7 @@ object ApiModule {
 
     @Singleton
     @Provides
-    fun provideFeedApi(@AuthRetrofit retrofit: Retrofit): FeedApi {
+    fun provideFeedApi(@NormalRetrofit retrofit: Retrofit): FeedApi {
         return retrofit.create(FeedApi::class.java)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.shypolarbear.android.di
 
 import com.shypolarbear.data.api.ExampleApi
 import com.shypolarbear.data.api.LoginApi
+import com.shypolarbear.data.api.TokenApi
 import com.shypolarbear.data.api.feed.FeedApi
 import dagger.Module
 import dagger.Provides
@@ -31,7 +32,13 @@ object ApiModule {
 
     @Singleton
     @Provides
-    fun provideFeedApi(@NormalRetrofit retrofit: Retrofit): FeedApi {
+    fun provideFeedApi(@AuthRetrofit retrofit: Retrofit): FeedApi {
         return retrofit.create(FeedApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideTokenRenewApi(@NormalRetrofit retrofit: Retrofit): TokenApi {
+        return retrofit.create(TokenApi::class.java)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/ApiModule.kt
@@ -9,7 +9,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
-import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -38,7 +37,7 @@ object ApiModule {
 
     @Singleton
     @Provides
-    fun provideTokenRenewApi(@NormalRetrofit retrofit: Retrofit): TokenApi {
+    fun provideTokenApi(@NormalRetrofit retrofit: Retrofit): TokenApi {
         return retrofit.create(TokenApi::class.java)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -21,7 +21,11 @@ class AuthInterceptor @Inject constructor(
 //        var accessToken = accessTokenUseCase.loadAccessToken()
 //        var refreshToken = refreshTokenUseCase.loadRefreshToken()
 
-//        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
+        // 임시 정의
+        var accessToken = "access token"
+        var refreshToken = "refresh token"
+
+//        val addedAccessTokenRequest = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
         val addedAccessTokenRequest = chain.request().newBuilder().addHeader("accessToken","testHeader").build()
         val response = chain.proceed(addedAccessTokenRequest)
 
@@ -29,12 +33,12 @@ class AuthInterceptor @Inject constructor(
             401 -> {
                 // Token 갱신하는 동작
                 runBlocking {
-                    val renewResponse = tokenRenewUseCase.loadTokens()
+                    val renewResponse = tokenRenewUseCase.loadTokens(refreshToken)
 
                     renewResponse
                         .onSuccess {
-                            var accessToken = it.data.accessToken
-                            var refreshToken = it.data.refreshToken
+                            accessToken = it.data.accessToken
+                            refreshToken = it.data.refreshToken
 
                             Timber.d("access token: $accessToken, refresh token: $refreshToken")
                         }
@@ -42,8 +46,9 @@ class AuthInterceptor @Inject constructor(
 
                         }
                 }
-            }
 
+            }
+            else -> response
         }
 
         Timber.d("헤더에 잘 붙음?: $addedAccessTokenRequest")

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -3,6 +3,7 @@ package com.shypolarbear.android.di
 import com.shypolarbear.domain.usecase.AccessTokenUseCase
 import okhttp3.Interceptor
 import okhttp3.Response
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,9 +12,12 @@ class AuthInterceptor @Inject constructor(
     private val accessTokenUseCase: AccessTokenUseCase
 ): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = accessTokenUseCase.loadAccessToken()
-        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
+        // TODO("TokenRepoImpl에서 토큰 가져오는 동작 구현되면 주석 해제하기")
+//        val accessToken = accessTokenUseCase.loadAccessToken()
+//        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
+        val request = chain.request().newBuilder().addHeader("accessToken","testHeader").build()
 
+        Timber.d("헤더에 잘 붙음?: $request")
         return chain.proceed(request)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -1,0 +1,10 @@
+package com.shypolarbear.android.di
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor: Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -1,10 +1,19 @@
 package com.shypolarbear.android.di
 
+import com.shypolarbear.domain.usecase.AccessTokenUseCase
 import okhttp3.Interceptor
 import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class AuthInterceptor: Interceptor {
+@Singleton
+class AuthInterceptor @Inject constructor(
+    private val accessTokenUseCase: AccessTokenUseCase
+): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        TODO("Not yet implemented")
+        val accessToken = accessTokenUseCase.loadAccessToken()
+        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
+
+        return chain.proceed(request)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -1,6 +1,7 @@
 package com.shypolarbear.android.di
 
 import com.shypolarbear.domain.usecase.AccessTokenUseCase
+import com.shypolarbear.domain.usecase.RefreshTokenUseCase
 import okhttp3.Interceptor
 import okhttp3.Response
 import timber.log.Timber
@@ -9,15 +10,26 @@ import javax.inject.Singleton
 
 @Singleton
 class AuthInterceptor @Inject constructor(
-    private val accessTokenUseCase: AccessTokenUseCase
+    private val accessTokenUseCase: AccessTokenUseCase,
+    private val refreshTokenUseCase: RefreshTokenUseCase
 ): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         // TODO("TokenRepoImpl에서 토큰 가져오는 동작 구현되면 주석 해제하기")
 //        val accessToken = accessTokenUseCase.loadAccessToken()
-//        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
-        val request = chain.request().newBuilder().addHeader("accessToken","testHeader").build()
+//        val refreshToken = refreshTokenUseCase.loadRefreshToken()
 
-        Timber.d("헤더에 잘 붙음?: $request")
-        return chain.proceed(request)
+//        val request = chain.request().newBuilder().addHeader("accessToken","$accessToken").build()
+        val addedAccessTokenRequest = chain.request().newBuilder().addHeader("accessToken","testHeader").build()
+        val response = chain.proceed(addedAccessTokenRequest)
+
+        when (response.code) {
+            401 -> {
+                // Access Token 갱신하는 동작
+            }
+        }
+
+        Timber.d("헤더에 잘 붙음?: $addedAccessTokenRequest")
+
+        return response
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthInterceptor.kt
@@ -18,8 +18,8 @@ class AuthInterceptor @Inject constructor(
 ): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         // TODO("TokenRepoImpl에서 토큰 가져오는 동작 구현되면 주석 해제하기")
-//        var accessToken = accessTokenUseCase.loadAccessToken()
-//        var refreshToken = refreshTokenUseCase.loadRefreshToken()
+//        var accessToken = accessTokenUseCase()
+//        var refreshToken = refreshTokenUseCase()
 
         // 임시 정의
         var accessToken = "access token"
@@ -33,7 +33,7 @@ class AuthInterceptor @Inject constructor(
             401 -> {
                 // Token 갱신하는 동작
                 runBlocking {
-                    val renewResponse = tokenRenewUseCase.loadTokens(refreshToken)
+                    val renewResponse = tokenRenewUseCase(refreshToken)
 
                     renewResponse
                         .onSuccess {

--- a/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
@@ -1,0 +1,43 @@
+package com.shypolarbear.android.di
+
+import com.shypolarbear.android.util.MOCK_URL
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthNetworkModule {
+
+    @Singleton
+    @Provides
+    @AuthOkHttp
+    fun provideAuthHttpClient(
+        logger: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(logger)
+            .addInterceptor(authInterceptor)
+            .build()
+    }
+    @Singleton
+    @Provides
+    @AuthRetrofit
+    fun provideAuthRetrofit(
+        @AuthOkHttp client: OkHttpClient
+    ): Retrofit {
+
+        return Retrofit.Builder()
+            .baseUrl(MOCK_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(client)
+            .build()
+    }
+}

--- a/app/src/main/java/com/shypolarbear/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/NetworkModule.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
 object NetworkModule {
     @Singleton
     @Provides
+    @NormalOkHttp
     fun provideHttpClient(
         logger: HttpLoggingInterceptor
     ): OkHttpClient {
@@ -53,8 +54,9 @@ object NetworkModule {
 
     @Singleton
     @Provides
+    @NormalRetrofit
     fun provideRetrofit(
-        client: OkHttpClient
+        @NormalOkHttp client: OkHttpClient
     ): Retrofit {
 
         return Retrofit.Builder()

--- a/app/src/main/java/com/shypolarbear/android/di/Qualifier.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/Qualifier.kt
@@ -1,0 +1,15 @@
+package com.shypolarbear.android.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class AuthOkHttp
+
+@Qualifier
+annotation class NormalOkHttp
+
+@Qualifier
+annotation class AuthRetrofit
+
+@Qualifier
+annotation class NormalRetrofit

--- a/app/src/main/java/com/shypolarbear/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/RepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.shypolarbear.android.di
 
 import com.shypolarbear.data.repositoryimpl.ExampleRepoImpl
+import com.shypolarbear.data.repositoryimpl.TokenRepoImpl
 import com.shypolarbear.data.repositoryimpl.feed.FeedRepoImpl
 import com.shypolarbear.domain.repository.ExampleRepo
+import com.shypolarbear.domain.repository.TokenRepo
 import com.shypolarbear.domain.repository.feed.FeedRepo
 import dagger.Binds
 import dagger.Module
@@ -18,4 +20,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindFeedTotalRepo(repoImp: FeedRepoImpl): FeedRepo
+
+    @Binds
+    abstract fun bindTokenRepo(repoImp: TokenRepoImpl): TokenRepo
 }

--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -9,6 +9,7 @@ import com.shypolarbear.domain.usecase.ExampleUseCase
 import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.domain.usecase.LoginUseCase
 import com.shypolarbear.domain.usecase.RefreshTokenUseCase
+import com.shypolarbear.domain.usecase.TokenRenewUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import dagger.Module
@@ -60,5 +61,11 @@ class UseCaseModule {
     @Provides
     fun provideRefreshTokenUseCase(repo: TokenRepo): RefreshTokenUseCase {
         return RefreshTokenUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideTokenRenewUseCase(repo: TokenRepo): TokenRenewUseCase {
+        return TokenRenewUseCase(repo)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -3,9 +3,12 @@ package com.shypolarbear.android.di
 import com.shypolarbear.domain.repository.ExampleRepo
 import com.shypolarbear.domain.repository.feed.FeedRepo
 import com.shypolarbear.domain.repository.LoginRepo
+import com.shypolarbear.domain.repository.TokenRepo
+import com.shypolarbear.domain.usecase.AccessTokenUseCase
 import com.shypolarbear.domain.usecase.ExampleUseCase
 import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.domain.usecase.LoginUseCase
+import com.shypolarbear.domain.usecase.RefreshTokenUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import dagger.Module
@@ -45,5 +48,17 @@ class UseCaseModule {
     @Provides
     fun provideFeedCommentUseCase(repo: FeedRepo): FeedCommentUseCase {
         return FeedCommentUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideAccessTokenUseCase(repo: TokenRepo): AccessTokenUseCase {
+        return AccessTokenUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideRefreshTokenUseCase(repo: TokenRepo): RefreshTokenUseCase {
+        return RefreshTokenUseCase(repo)
     }
 }

--- a/data/src/main/java/com/shypolarbear/data/api/TokenApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/TokenApi.kt
@@ -1,10 +1,18 @@
 package com.shypolarbear.data.api
 
 import com.shypolarbear.domain.model.TokenRenew
+import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface TokenApi {
     @POST("/api/auth/reissue")
-    suspend fun renewToken(): Response<TokenRenew>
+    suspend fun renewToken(
+        @Body
+        refreshToken: String
+    ): Response<TokenRenew>
+
 }

--- a/data/src/main/java/com/shypolarbear/data/api/TokenApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/TokenApi.kt
@@ -1,0 +1,10 @@
+package com.shypolarbear.data.api
+
+import com.shypolarbear.domain.model.TokenRenew
+import retrofit2.Response
+import retrofit2.http.POST
+
+interface TokenApi {
+    @POST("/api/auth/reissue")
+    suspend fun renewToken(): Response<TokenRenew>
+}

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
@@ -18,9 +18,9 @@ class TokenRepoImpl @Inject constructor(
         TODO("DataStore에서 Refresh Token 가져오는 동작")
     }
 
-    override suspend fun renewTokens(): Result<TokenRenew> {
+    override suspend fun renewTokens(refreshToken: String): Result<TokenRenew> {
         return try {
-            val response = api.renewToken()
+            val response = api.renewToken(refreshToken)
             when {
                 response.isSuccessful -> {
                     Result.success(response.body()!!)

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
@@ -1,8 +1,11 @@
 package com.shypolarbear.data.repositoryimpl
 
 import com.shypolarbear.domain.repository.TokenRepo
+import javax.inject.Inject
 
-class TokenRepoImpl: TokenRepo {
+class TokenRepoImpl @Inject constructor(
+
+): TokenRepo {
     override fun getAccessToken() {
         TODO("DataStore에서 Access Token 가져오는 동작")
     }

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
@@ -1,16 +1,36 @@
 package com.shypolarbear.data.repositoryimpl
 
+import com.shypolarbear.data.api.TokenApi
+import com.shypolarbear.domain.model.HttpError
+import com.shypolarbear.domain.model.TokenRenew
+import com.shypolarbear.domain.model.feed.FeedTotal
 import com.shypolarbear.domain.repository.TokenRepo
 import javax.inject.Inject
 
 class TokenRepoImpl @Inject constructor(
-
+    private val api: TokenApi
 ): TokenRepo {
-    override fun getAccessToken() {
+    override fun getAccessToken(): String {
         TODO("DataStore에서 Access Token 가져오는 동작")
     }
 
-    override fun getRefreshToken() {
+    override fun getRefreshToken(): String {
         TODO("DataStore에서 Refresh Token 가져오는 동작")
+    }
+
+    override suspend fun renewTokens(): Result<TokenRenew> {
+        return try {
+            val response = api.renewToken()
+            when {
+                response.isSuccessful -> {
+                    Result.success(response.body()!!)
+                }
+                else -> {
+                    Result.failure(HttpError(response.code(), response.errorBody()?.string() ?: ""))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/TokenRepoImpl.kt
@@ -1,0 +1,13 @@
+package com.shypolarbear.data.repositoryimpl
+
+import com.shypolarbear.domain.repository.TokenRepo
+
+class TokenRepoImpl: TokenRepo {
+    override fun getAccessToken() {
+        TODO("DataStore에서 Access Token 가져오는 동작")
+    }
+
+    override fun getRefreshToken() {
+        TODO("DataStore에서 Refresh Token 가져오는 동작")
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/model/TokenRenew.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/TokenRenew.kt
@@ -1,0 +1,9 @@
+package com.shypolarbear.domain.model
+
+import com.shypolarbear.domain.model.login.Tokens
+
+data class TokenRenew (
+    val code: Int,
+    val data: Tokens,
+    val message: String
+)

--- a/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
@@ -1,0 +1,7 @@
+package com.shypolarbear.domain.repository
+
+interface TokenRepo {
+    fun getAccessToken()
+
+    fun getRefreshToken()
+}

--- a/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
@@ -1,7 +1,11 @@
 package com.shypolarbear.domain.repository
 
-interface TokenRepo {
-    fun getAccessToken()
+import com.shypolarbear.domain.model.TokenRenew
 
-    fun getRefreshToken()
+interface TokenRepo {
+    fun getAccessToken(): String
+
+    fun getRefreshToken(): String
+
+    suspend fun renewTokens(): Result<TokenRenew>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/TokenRepo.kt
@@ -7,5 +7,5 @@ interface TokenRepo {
 
     fun getRefreshToken(): String
 
-    suspend fun renewTokens(): Result<TokenRenew>
+    suspend fun renewTokens(refreshToken: String): Result<TokenRenew>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
@@ -5,7 +5,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class AccessTokenUseCase (
     private val repo: TokenRepo
 ){
-    fun loadAccessToken(): String {
+    operator fun invoke(): String {
         return repo.getAccessToken()
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
@@ -1,0 +1,11 @@
+package com.shypolarbear.domain.usecase
+
+import com.shypolarbear.domain.repository.TokenRepo
+
+class AccessTokenUseCase (
+    private val repo: TokenRepo
+){
+    fun loadAccessToken() {
+        return repo.getAccessToken()
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/AccessTokenUseCase.kt
@@ -5,7 +5,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class AccessTokenUseCase (
     private val repo: TokenRepo
 ){
-    fun loadAccessToken() {
+    fun loadAccessToken(): String {
         return repo.getAccessToken()
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
@@ -5,7 +5,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class RefreshTokenUseCase (
     private val repo: TokenRepo
 ){
-    fun loadRefreshToken(): String {
+    operator fun invoke(): String {
         return repo.getRefreshToken()
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
@@ -1,0 +1,11 @@
+package com.shypolarbear.domain.usecase
+
+import com.shypolarbear.domain.repository.TokenRepo
+
+class RefreshTokenUseCase (
+    private val repo: TokenRepo
+){
+    fun loadRefreshToken() {
+        return repo.getRefreshToken()
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/RefreshTokenUseCase.kt
@@ -5,7 +5,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class RefreshTokenUseCase (
     private val repo: TokenRepo
 ){
-    fun loadRefreshToken() {
+    fun loadRefreshToken(): String {
         return repo.getRefreshToken()
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
@@ -6,7 +6,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class TokenRenewUseCase (
     private val repo: TokenRepo
 ){
-    suspend fun loadTokens(refreshToken: String): Result<TokenRenew> {
+    suspend operator fun invoke(refreshToken: String): Result<TokenRenew> {
         return repo.renewTokens(refreshToken)
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
@@ -1,0 +1,12 @@
+package com.shypolarbear.domain.usecase
+
+import com.shypolarbear.domain.model.TokenRenew
+import com.shypolarbear.domain.repository.TokenRepo
+
+class TokenRenewUseCase (
+    private val repo: TokenRepo
+){
+    suspend fun loadTokens(): Result<TokenRenew> {
+        return repo.renewTokens()
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/TokenRenewUseCase.kt
@@ -6,7 +6,7 @@ import com.shypolarbear.domain.repository.TokenRepo
 class TokenRenewUseCase (
     private val repo: TokenRepo
 ){
-    suspend fun loadTokens(): Result<TokenRenew> {
-        return repo.renewTokens()
+    suspend fun loadTokens(refreshToken: String): Result<TokenRenew> {
+        return repo.renewTokens(refreshToken)
     }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- interceptor로 요청 시 ac token 자동으로 포함하여 전달하는 로직 구현
- 토큰 자동 갱신 로직 임시 구현

🌱 PR 포인트
- 요청 시 토큰이 필요한 동작은 ApiModule에서 retrofit 객체를 생성할 때 @AuthRetrofit을 사용하면 됩니다.
ex)
```
   @Singleton
    @Provides
    fun provideFeedApi(@AuthRetrofit retrofit: Retrofit): FeedApi {
        return retrofit.create(FeedApi::class.java)
    }
```
- 토큰 만료 시 응답 상태 코드가 401이기 때문에 interceptor에서 401 응답에 경우 토큰 재발급 받는 요청을 하게 하였습니다.

- 로그 캡쳐 이미지를 보면 AuthRetrofit으로 요청한 경우 헤더에 토큰이 붙는 것을 확인할 수 있고, 401 응답이 온 경우 자동으로 토큰을 재발급 받는 동작을 하는 것을 확인할 수 있습니다.

## 📸 스크린샷
|스크린샷|
![토큰 관련 로직 테스트 로그](https://github.com/ShyPolarBear/Android/assets/107917980/490ce2d9-198e-4902-9fe2-9ed720a762a9)


|파일첨부바람|

## 📮 관련 이슈
- Resolved: #47 
