### PR TITLE
[WBS-193]Feature/add feed write UI

### DIFF
--- a/app/src/main/java/com/shypolarbear/android/util/Constant.kt
+++ b/app/src/main/java/com/shypolarbear/android/util/Constant.kt
@@ -2,5 +2,5 @@ package com.shypolarbear.android.util
 
 const val BASE_URL = "http://3.37.80.247:8080/"
 const val SAMPLE_URL = "https://api.chucknorris.io/"
-const val MOCK_URL = "https://ed3bf92e-bc49-483f-85b9-c042456779e9.mock.pstmn.io"
+const val MOCK_URL = "https://ec4049d6-e0e0-494c-a4bc-638ad060740c.mock.pstmn.io"
 const val RETROFIT_TAG = "Retrofit Tag"

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
@@ -1,7 +1,5 @@
 package com.shypolarbear.domain.model.feed
 
-import com.sun.jndi.toolkit.url.Uri
-
-data class FeedWriteImg (
-    val imgUrl: Uri
+data class FeedWriteImg(
+    val imgUrl: String
 )

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
@@ -1,0 +1,7 @@
+package com.shypolarbear.domain.model.feed
+
+import com.sun.jndi.toolkit.url.Uri
+
+data class FeedWriteImg (
+    val imgUrl: Uri
+)

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
@@ -59,29 +59,34 @@ class FeedDetailFragment : BaseFragment<FragmentFeedDetailBinding, FeedDetailVie
 
     override fun initView() {
 
-        binding.btnFeedDetailBack.setOnClickListener {
-            findNavController().navigate(R.id.action_feedDetailFragment_to_feedTotalFragment)
-        }
+        binding.apply {
+            layoutFeedDetail.isVisible = false
+            progressFeedDetailLoading.isVisible = true
 
-        binding.edtFeedDetailReply.setOnFocusChangeListener { _, isFocus ->
-            binding.cardviewFeedCommentWritingMsg.isVisible = isFocus
-        }
+            btnFeedDetailBack.setOnClickListener {
+                findNavController().navigate(R.id.action_feedDetailFragment_to_feedTotalFragment)
+            }
 
-        binding.layoutFeedDetail.setOnClickListener {
-            binding.edtFeedDetailReply.clearFocus()
-        }
+            edtFeedDetailReply.setOnFocusChangeListener { _, isFocus ->
+                binding.cardviewFeedCommentWritingMsg.isVisible = isFocus
+            }
 
-        binding.btnFeedCommentWritingClose.setOnClickListener {
-            binding.cardviewFeedCommentWritingMsg.isVisible = false
-        }
+            layoutFeedDetail.setOnClickListener {
+                binding.edtFeedDetailReply.clearFocus()
+            }
 
-        viewModel.loadFeedDetail(feedDetailArgs.feedId)
-        viewModel.loadFeedComment(feedDetailArgs.feedId)
+            btnFeedCommentWritingClose.setOnClickListener {
+                binding.cardviewFeedCommentWritingMsg.isVisible = false
+            }
 
-        viewModel.feed.observe(viewLifecycleOwner) {feed ->
-            setFeedPost(feed)
+            viewModel.loadFeedDetail(feedDetailArgs.feedId)
+            viewModel.loadFeedComment(feedDetailArgs.feedId)
+
+            viewModel.feed.observe(viewLifecycleOwner) {feed ->
+                setFeedPost(feed)
+            }
+            setFeedComment()
         }
-        setFeedComment()
     }
 
     private fun setFeedPost(feedDetail: Feed) {
@@ -158,6 +163,8 @@ class FeedDetailFragment : BaseFragment<FragmentFeedDetailBinding, FeedDetailVie
         binding.rvFeedDetailReply.adapter = feedCommentAdapter
         viewModel.feedComment.observe(viewLifecycleOwner) {
             feedCommentAdapter.submitList(it)
+            binding.layoutFeedDetail.isVisible = true
+            binding.progressFeedDetailLoading.isVisible = false
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
@@ -59,9 +59,6 @@ class FeedDetailFragment : BaseFragment<FragmentFeedDetailBinding, FeedDetailVie
 
     override fun initView() {
 
-        val bottomNavigationViewMainActivity = requireActivity().findViewById<BottomNavigationView>(R.id.bottom_navigation_bar)
-        bottomNavigationViewMainActivity.isVisible = false
-
         binding.btnFeedDetailBack.setOnClickListener {
             findNavController().navigate(R.id.action_feedDetailFragment_to_feedTotalFragment)
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -65,6 +65,9 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
     override fun initView() {
 
         binding.apply {
+            binding.progressFeedTotalLoading.isVisible = true
+            binding.layoutFeed.isVisible = false
+
             viewModel.loadFeedTotalData()
 
             ivFeedToolbarSort.setOnClickListener {
@@ -86,6 +89,8 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         binding.rvFeedPost.adapter = feedPostAdapter
         lifecycleScope.launch {
             viewModel.feed.observe(viewLifecycleOwner) {
+                binding.progressFeedTotalLoading.isVisible = false
+                binding.layoutFeed.isVisible = true
                 feedPostAdapter.submitList(it)
             }
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -77,6 +77,10 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                     viewLifecycleOwner
                 )
             }
+
+            btnFeedPostWrite.setOnClickListener {
+                findNavController().navigate(R.id.action_navigation_feed_to_feedWriteFragment)
+            }
             setFeedPost()
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -89,9 +89,9 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         binding.rvFeedPost.adapter = feedPostAdapter
         lifecycleScope.launch {
             viewModel.feed.observe(viewLifecycleOwner) {
+                feedPostAdapter.submitList(it)
                 binding.progressFeedTotalLoading.isVisible = false
                 binding.layoutFeed.isVisible = true
-                feedPostAdapter.submitList(it)
             }
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -64,9 +64,6 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
 
     override fun initView() {
 
-        val bottomNavigationViewMainActivity = requireActivity().findViewById<BottomNavigationView>(R.id.bottom_navigation_bar)
-        bottomNavigationViewMainActivity.isVisible = true
-
         binding.apply {
             viewModel.loadFeedTotalData()
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -8,15 +8,21 @@ import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
+import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
+//@AndroidEntryPoint
 class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewModel > (
     R.layout.fragment_feed_write
 ) {
 
     override val viewModel: FeedWriteViewModel by viewModels()
-    private val feedWriteImgAdapter = FeedWriteImgAdapter()
+    private val feedWriteImgAdapter = FeedWriteImgAdapter(
+        onRemoveImgClick = { position: Int -> removeImg(position) }
+    )
 
-    private val imgTestList: MutableList<FeedWriteImg> = mutableListOf(
+    // 임시 데이터
+    private var imgTestList: MutableList<FeedWriteImg> = mutableListOf(
         FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
         FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
         FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
@@ -30,6 +36,7 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
             feedWriteImgAdapter.submitList(imgTestList)
+            Timber.d("전달 된 리스트: $imgTestList")
 
             btnFeedWriteBack.setOnClickListener {
                 findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
@@ -43,8 +50,18 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                 else
                     findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
 
-
             }
         }
+    }
+
+    private fun removeImg(position: Int) {
+        binding.apply {
+            imgTestList.removeAt(position)
+            Timber.d("아이템: $imgTestList")
+
+            rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
+            Timber.d("$position 번째 아이템")
+        }
+
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -46,10 +46,7 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
             viewModel.liveImgList.observe(viewLifecycleOwner) {
-                var applyChangeList: MutableList<FeedWriteImg> = mutableListOf()
-                applyChangeList.addAll(it)
-
-                feedWriteImgAdapter.submitList(applyChangeList)
+                feedWriteImgAdapter.submitList(it.toList())
             }
 
             btnFeedWriteBack.setOnClickListener {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,7 +1,6 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import android.widget.Toast
-import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.shypolarbear.domain.model.feed.FeedWriteImg
@@ -11,7 +10,7 @@ import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
-//@AndroidEntryPoint
+@AndroidEntryPoint
 class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewModel > (
     R.layout.fragment_feed_write
 ) {
@@ -21,21 +20,13 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
         onRemoveImgClick = { position: Int -> removeImg(position) }
     )
 
-    // 임시 데이터
-    private var imgTestList: MutableList<FeedWriteImg> = mutableListOf(
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
-        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405")
-    )
-
     override fun initView() {
         binding.apply {
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
-            feedWriteImgAdapter.submitList(imgTestList)
+            viewModel.testImgList.observe(viewLifecycleOwner) {
+                feedWriteImgAdapter.submitList(it)
+            }
 
             btnFeedWriteBack.setOnClickListener {
                 findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
@@ -58,17 +49,16 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun addImg() {
-        imgTestList.add(0, FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/30b3d3c8-f2d8-4760-9912-faeec239fe34"))
+        viewModel.addImgList()
         binding.rvFeedWriteUploadImg.adapter!!.notifyItemInserted(0)
         binding.rvFeedWriteUploadImg.scrollToPosition(0)
     }
 
     private fun removeImg(position: Int) {
-        imgTestList.removeAt(position)
-        Timber.d("아이템: $imgTestList")
+        viewModel.removeImgList(position)
 
         binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
-        Timber.d("$position 번째 아이템")
+        Timber.d("${position + 1} 번째 아이템")
 
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -21,17 +21,19 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 ) {
 
     override val viewModel: FeedWriteViewModel by viewModels()
+    private val feedWriteImgAdapter = FeedWriteImgAdapter(
+        onRemoveImgClick = { position: Int -> removeImg(position) }
+    )
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(IMAGE_MAX_COUNT)) { uris ->
             uris?.let {
-                Timber.d("${viewModel.testImgList.value!!.size + uris.size}")
-                when(viewModel.testImgList.value!!.size + uris.size) {
+                Timber.d("${viewModel.liveImgList.value!!.size + uris.size}")
+                when(viewModel.liveImgList.value!!.size + uris.size) {
                     in IMAGE_ADD_MAX..Int.MAX_VALUE -> {
                         Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
                     }
                     else -> {
                         viewModel.addImgList(uris)
-                        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRangeInserted(IMAGE_ADD_INDEX, uris.size)
                         binding.rvFeedWriteUploadImg.scrollToPosition(IMAGE_ADD_INDEX)
                     }
                 }
@@ -39,16 +41,14 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
             }
         }
 
-    private val feedWriteImgAdapter = FeedWriteImgAdapter(
-        onRemoveImgClick = { position: Int -> removeImg(position) }
-    )
-
     override fun initView() {
         binding.apply {
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
-            viewModel.testImgList.observe(viewLifecycleOwner) {
+            viewModel.liveImgList.observe(viewLifecycleOwner) {
+                Timber.d("3")
                 feedWriteImgAdapter.submitList(it)
+                Timber.d("이미지 리스트 변경 감지, it: $it")
             }
 
             btnFeedWriteBack.setOnClickListener {
@@ -72,7 +72,7 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun addImg() {
-        when(viewModel.testImgList.value!!.size) {
+        when(viewModel.liveImgList.value!!.size) {
             in IMAGE_MAX_COUNT..Int.MAX_VALUE -> {
                 Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
             }
@@ -83,7 +83,9 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun removeImg(position: Int) {
+        Timber.d("2")
         viewModel.removeImgList(position)
-        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
+
+//        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -11,6 +11,10 @@ import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
+const val IMAGE_ADD_INDEX = 0
+const val IMAGE_MAX_COUNT = 5
+const val IMAGE_ADD_MAX = 6
+
 @AndroidEntryPoint
 class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewModel > (
     R.layout.fragment_feed_write
@@ -18,11 +22,20 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
     override val viewModel: FeedWriteViewModel by viewModels()
     private val pickMedia =
-        registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(5)) { uris ->
+        registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(IMAGE_MAX_COUNT)) { uris ->
             uris?.let {
-                viewModel.addImgList(uris)
-                binding.rvFeedWriteUploadImg.adapter!!.notifyItemRangeChanged(0, uris.size)
-                binding.rvFeedWriteUploadImg.scrollToPosition(0)
+                Timber.d("${viewModel.testImgList.value!!.size + uris.size}")
+                when(viewModel.testImgList.value!!.size + uris.size) {
+                    in IMAGE_ADD_MAX..Int.MAX_VALUE -> {
+                        Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
+                    }
+                    else -> {
+                        viewModel.addImgList(uris)
+                        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRangeInserted(IMAGE_ADD_INDEX, uris.size)
+                        binding.rvFeedWriteUploadImg.scrollToPosition(IMAGE_ADD_INDEX)
+                    }
+                }
+
             }
         }
 
@@ -59,13 +72,18 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun addImg() {
-        pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        when(viewModel.testImgList.value!!.size) {
+            in IMAGE_MAX_COUNT..Int.MAX_VALUE -> {
+                Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
+            }
+            else -> {
+                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            }
+        }
     }
 
     private fun removeImg(position: Int) {
         viewModel.removeImgList(position)
         binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
-        Timber.d("${position + 1} 번째 아이템")
-
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,0 +1,17 @@
+package com.shypolarbear.presentation.ui.feed.feedWrite
+
+import androidx.fragment.app.viewModels
+import com.shypolarbear.presentation.R
+import com.shypolarbear.presentation.base.BaseFragment
+import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
+
+class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewModel > (
+    R.layout.fragment_feed_write
+) {
+
+    override val viewModel: FeedWriteViewModel by viewModels()
+
+    override fun initView() {
+
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -36,10 +36,13 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
             feedWriteImgAdapter.submitList(imgTestList)
-            Timber.d("전달 된 리스트: $imgTestList")
 
             btnFeedWriteBack.setOnClickListener {
                 findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+            }
+
+            btnFeedWriteAddPhoto.setOnClickListener {
+                addImg()
             }
 
             btnFeedWriteConfirm.setOnClickListener {
@@ -54,14 +57,18 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
         }
     }
 
-    private fun removeImg(position: Int) {
-        binding.apply {
-            imgTestList.removeAt(position)
-            Timber.d("아이템: $imgTestList")
+    private fun addImg() {
+        imgTestList.add(0, FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/30b3d3c8-f2d8-4760-9912-faeec239fe34"))
+        binding.rvFeedWriteUploadImg.adapter!!.notifyItemInserted(0)
+        binding.rvFeedWriteUploadImg.scrollToPosition(0)
+    }
 
-            rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
-            Timber.d("$position 번째 아이템")
-        }
+    private fun removeImg(position: Int) {
+        imgTestList.removeAt(position)
+        Timber.d("아이템: $imgTestList")
+
+        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
+        Timber.d("$position 번째 아이템")
 
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,6 +1,7 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
@@ -12,6 +13,10 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     override val viewModel: FeedWriteViewModel by viewModels()
 
     override fun initView() {
-
+        binding.apply {
+            btnFeedWriteBack.setOnClickListener {
+                findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,8 +1,10 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import android.widget.Toast
+import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
@@ -12,9 +14,23 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 ) {
 
     override val viewModel: FeedWriteViewModel by viewModels()
+    private val feedWriteImgAdapter = FeedWriteImgAdapter()
+
+    private val imgTestList: MutableList<FeedWriteImg> = mutableListOf(
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405"),
+        FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/9690c7b7-2bde-498c-a5be-886b6e5b5405")
+    )
 
     override fun initView() {
         binding.apply {
+
+            rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
+            feedWriteImgAdapter.submitList(imgTestList)
+
             btnFeedWriteBack.setOnClickListener {
                 findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,9 +1,10 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import android.widget.Toast
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
@@ -16,6 +17,15 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 ) {
 
     override val viewModel: FeedWriteViewModel by viewModels()
+    private val pickMedia =
+        registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(5)) { uris ->
+            uris?.let {
+                viewModel.addImgList(uris)
+                binding.rvFeedWriteUploadImg.adapter!!.notifyItemRangeChanged(0, uris.size)
+                binding.rvFeedWriteUploadImg.scrollToPosition(0)
+            }
+        }
+
     private val feedWriteImgAdapter = FeedWriteImgAdapter(
         onRemoveImgClick = { position: Int -> removeImg(position) }
     )
@@ -49,14 +59,11 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun addImg() {
-        viewModel.addImgList()
-        binding.rvFeedWriteUploadImg.adapter!!.notifyItemInserted(0)
-        binding.rvFeedWriteUploadImg.scrollToPosition(0)
+        pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
     }
 
     private fun removeImg(position: Int) {
         viewModel.removeImgList(position)
-
         binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
         Timber.d("${position + 1} 번째 아이템")
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -1,5 +1,6 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.shypolarbear.presentation.R
@@ -16,6 +17,17 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
         binding.apply {
             btnFeedWriteBack.setOnClickListener {
                 findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+            }
+
+            btnFeedWriteConfirm.setOnClickListener {
+                if (edtFeedWriteTitle.text.toString().isBlank())
+                    Toast.makeText(requireContext(), "제목을 입력해주세요", Toast.LENGTH_SHORT).show()
+                else if (edtFeedWriteContent.text.toString().isBlank())
+                    Toast.makeText(requireContext(), "내용을 입력해주세요", Toast.LENGTH_SHORT).show()
+                else
+                    findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+
+
             }
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -47,9 +47,9 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
             btnFeedWriteConfirm.setOnClickListener {
                 if (edtFeedWriteTitle.text.toString().isBlank())
-                    Toast.makeText(requireContext(), "제목을 입력해주세요", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.feed_write_title_msg), Toast.LENGTH_SHORT).show()
                 else if (edtFeedWriteContent.text.toString().isBlank())
-                    Toast.makeText(requireContext(), "내용을 입력해주세요", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.feed_write_content_msg), Toast.LENGTH_SHORT).show()
                 else
                     findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
@@ -27,7 +28,6 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(IMAGE_MAX_COUNT)) { uris ->
             uris?.let {
-                Timber.d("${viewModel.liveImgList.value!!.size + uris.size}")
                 when(viewModel.liveImgList.value!!.size + uris.size) {
                     in IMAGE_ADD_MAX..Int.MAX_VALUE -> {
                         Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
@@ -46,9 +46,10 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
             viewModel.liveImgList.observe(viewLifecycleOwner) {
-                Timber.d("3")
-                feedWriteImgAdapter.submitList(it)
-                Timber.d("이미지 리스트 변경 감지, it: $it")
+                var applyChangeList: MutableList<FeedWriteImg> = mutableListOf()
+                applyChangeList.addAll(it)
+
+                feedWriteImgAdapter.submitList(applyChangeList)
             }
 
             btnFeedWriteBack.setOnClickListener {
@@ -87,9 +88,6 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
     }
 
     private fun removeImg(position: Int) {
-        Timber.d("2")
         viewModel.removeImgList(position)
-
-//        binding.rvFeedWriteUploadImg.adapter!!.notifyItemRemoved(position)
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -60,13 +60,17 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
             }
 
             btnFeedWriteConfirm.setOnClickListener {
-                if (edtFeedWriteTitle.text.toString().isBlank())
-                    Toast.makeText(requireContext(), getString(R.string.feed_write_title_msg), Toast.LENGTH_SHORT).show()
-                else if (edtFeedWriteContent.text.toString().isBlank())
-                    Toast.makeText(requireContext(), getString(R.string.feed_write_content_msg), Toast.LENGTH_SHORT).show()
-                else
-                    findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
-
+                when {
+                    edtFeedWriteTitle.text.toString().isBlank() -> {
+                        Toast.makeText(requireContext(), getString(R.string.feed_write_title_msg), Toast.LENGTH_SHORT).show()
+                    }
+                    edtFeedWriteContent.text.toString().isBlank() -> {
+                        Toast.makeText(requireContext(), getString(R.string.feed_write_content_msg), Toast.LENGTH_SHORT).show()
+                    }
+                    else -> {
+                        findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+                    }
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
+import timber.log.Timber
 
 class FeedWriteImgAdapter(
     private val onRemoveImgClick: (position: Int) -> Unit = { _ -> }
@@ -23,6 +24,7 @@ class FeedWriteImgAdapter(
     }
 
     override fun onBindViewHolder(holder: FeedWriteImgViewHolder, position: Int) {
+        Timber.d("4")
         holder.bind(getItem(position))
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
@@ -24,7 +24,6 @@ class FeedWriteImgAdapter(
     }
 
     override fun onBindViewHolder(holder: FeedWriteImgViewHolder, position: Int) {
-        Timber.d("4")
         holder.bind(getItem(position))
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
@@ -2,18 +2,24 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
 
-class FeedWriteImgAdapter(): ListAdapter<FeedWriteImg, FeedWriteImgViewHolder>(FeedWriteImgDiffCallback()) {
+class FeedWriteImgAdapter(
+    private val onRemoveImgClick: (position: Int) -> Unit = { _ -> }
+): ListAdapter<FeedWriteImg, FeedWriteImgViewHolder>(FeedWriteImgDiffCallback()) {
 
     private lateinit var binding : ItemFeedWriteImgBinding
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedWriteImgViewHolder {
         binding = ItemFeedWriteImgBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return FeedWriteImgViewHolder(binding)
+        return FeedWriteImgViewHolder(
+            binding,
+            onRemoveImgClick = onRemoveImgClick,
+        )
     }
 
     override fun onBindViewHolder(holder: FeedWriteImgViewHolder, position: Int) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
@@ -1,0 +1,33 @@
+package com.shypolarbear.presentation.ui.feed.feedWrite
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
+
+class FeedWriteImgAdapter(): ListAdapter<FeedWriteImg, FeedWriteImgViewHolder>(FeedWriteImgDiffCallback()) {
+
+    private lateinit var binding : ItemFeedWriteImgBinding
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedWriteImgViewHolder {
+        binding = ItemFeedWriteImgBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return FeedWriteImgViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: FeedWriteImgViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+class FeedWriteImgDiffCallback : DiffUtil.ItemCallback<FeedWriteImg>() {
+
+    override fun areItemsTheSame(oldItem: FeedWriteImg, newItem: FeedWriteImg): Boolean {
+        return oldItem.imgUrl == newItem.imgUrl
+    }
+
+    override fun areContentsTheSame(oldItem: FeedWriteImg, newItem: FeedWriteImg): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -1,0 +1,20 @@
+package com.shypolarbear.presentation.ui.feed.feedWrite
+
+import androidx.recyclerview.widget.RecyclerView
+import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
+
+class FeedWriteImgViewHolder(
+    private val binding: ItemFeedWriteImgBinding
+): RecyclerView.ViewHolder(binding.root) {
+    init {
+
+    }
+
+    fun bind(item: FeedWriteImg) {
+        binding.apply {
+
+            executePendingBindings()
+        }
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -15,6 +15,7 @@ class FeedWriteImgViewHolder(
     init {
         binding.apply {
             btnRemoveUploadImg.setOnClickListener {
+                Timber.d("1")
                 onRemoveImgClick(adapterPosition)
             }
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -3,6 +3,7 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
+import com.shypolarbear.presentation.util.GlideUtil
 
 class FeedWriteImgViewHolder(
     private val binding: ItemFeedWriteImgBinding
@@ -13,6 +14,7 @@ class FeedWriteImgViewHolder(
 
     fun bind(item: FeedWriteImg) {
         binding.apply {
+            GlideUtil.loadImage(itemView.context, item.imgUrl, binding.ivFeedWriteImg)
 
             executePendingBindings()
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -1,5 +1,6 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
@@ -21,8 +22,8 @@ class FeedWriteImgViewHolder(
 
     fun bind(item: FeedWriteImg) {
         binding.apply {
-            GlideUtil.loadImage(itemView.context, item.imgUrl, binding.ivFeedWriteImg)
-
+            GlideUtil.loadImage(itemView.context, item.imgUrl.toUri(), binding.ivFeedWriteImg)
+            Timber.d("이미지 uri: $item.imgUrl")
             executePendingBindings()
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -3,6 +3,7 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
 import com.shypolarbear.presentation.util.GlideUtil
 import timber.log.Timber
@@ -15,7 +16,6 @@ class FeedWriteImgViewHolder(
         binding.apply {
             btnRemoveUploadImg.setOnClickListener {
                 onRemoveImgClick(adapterPosition)
-                Timber.d("$adapterPosition 번째 아이템")
             }
         }
     }
@@ -23,7 +23,6 @@ class FeedWriteImgViewHolder(
     fun bind(item: FeedWriteImg) {
         binding.apply {
             GlideUtil.loadImage(itemView.context, item.imgUrl.toUri(), binding.ivFeedWriteImg)
-            Timber.d("이미지 uri: $item.imgUrl")
             executePendingBindings()
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -15,7 +15,6 @@ class FeedWriteImgViewHolder(
     init {
         binding.apply {
             btnRemoveUploadImg.setOnClickListener {
-                Timber.d("1")
                 onRemoveImgClick(adapterPosition)
             }
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -4,12 +4,19 @@ import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
 import com.shypolarbear.presentation.util.GlideUtil
+import timber.log.Timber
 
 class FeedWriteImgViewHolder(
-    private val binding: ItemFeedWriteImgBinding
+    private val binding: ItemFeedWriteImgBinding,
+    private val onRemoveImgClick: (position: Int) -> Unit = { _ -> }
 ): RecyclerView.ViewHolder(binding.root) {
     init {
-
+        binding.apply {
+            btnRemoveUploadImg.setOnClickListener {
+                onRemoveImgClick(adapterPosition)
+                Timber.d("$adapterPosition 번째 아이템")
+            }
+        }
     }
 
     fun bind(item: FeedWriteImg) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -9,19 +9,27 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import timber.log.Timber
 import javax.inject.Inject
 
+
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
 
 ): BaseViewModel(){
-    private val _testImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
-    val testImgList: LiveData<MutableList<FeedWriteImg>> = _testImgList
+    private val _liveImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
+    val liveImgList: LiveData<MutableList<FeedWriteImg>> = _liveImgList
 
     fun addImgList(imgUri: List<Uri>) {
+        val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!
         val feedWriteImgList = imgUri.map { FeedWriteImg(it.toString()) }
-        _testImgList.value!!.addAll(0, feedWriteImgList)
+
+        imgList.addAll(0, feedWriteImgList)
+        _liveImgList.value = imgList
     }
 
     fun removeImgList(position: Int) {
-        _testImgList.value!!.removeAt(position)
+        Timber.d("4")
+        val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!
+
+        imgList.removeAt(position)
+        _liveImgList.value = imgList
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -1,0 +1,6 @@
+package com.shypolarbear.presentation.ui.feed.feedWrite
+
+import com.shypolarbear.presentation.base.BaseViewModel
+
+class FeedWriteViewModel: BaseViewModel(){
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -1,10 +1,12 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,8 +19,10 @@ class FeedWriteViewModel @Inject constructor(
         _testImgList.value = mutableListOf()
     }
 
-    fun addImgList() {
-        _testImgList.value!!.add(0, FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/30b3d3c8-f2d8-4760-9912-faeec239fe34"))
+    fun addImgList(imgUri: List<Uri>) {
+        val feedWriteImgList = imgUri.map { FeedWriteImg(it.toString()) }
+        _testImgList.value!!.addAll(0, feedWriteImgList)
+        Timber.d("이미지 리스트: ${_testImgList.value}")
     }
 
     fun removeImgList(position: Int) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -1,9 +1,27 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-//@HiltViewModel
-class FeedWriteViewModel: BaseViewModel(){
+@HiltViewModel
+class FeedWriteViewModel @Inject constructor(
 
+): BaseViewModel(){
+    private val _testImgList = MutableLiveData<MutableList<FeedWriteImg>>()
+    val testImgList: LiveData<MutableList<FeedWriteImg>> = _testImgList
+    init {
+        _testImgList.value = mutableListOf()
+    }
+
+    fun addImgList() {
+        _testImgList.value!!.add(0, FeedWriteImg("https://github.com/ShyPolarBear/Android/assets/107917980/30b3d3c8-f2d8-4760-9912-faeec239fe34"))
+    }
+
+    fun removeImgList(position: Int) {
+        _testImgList.value!!.removeAt(position)
+    }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -13,11 +13,8 @@ import javax.inject.Inject
 class FeedWriteViewModel @Inject constructor(
 
 ): BaseViewModel(){
-    private val _testImgList = MutableLiveData<MutableList<FeedWriteImg>>()
+    private val _testImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
     val testImgList: LiveData<MutableList<FeedWriteImg>> = _testImgList
-    init {
-        _testImgList.value = mutableListOf()
-    }
 
     fun addImgList(imgUri: List<Uri>) {
         val feedWriteImgList = imgUri.map { FeedWriteImg(it.toString()) }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -1,6 +1,9 @@
 package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import com.shypolarbear.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 
+//@HiltViewModel
 class FeedWriteViewModel: BaseViewModel(){
+
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -9,7 +9,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import timber.log.Timber
 import javax.inject.Inject
 
-
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
 
@@ -26,7 +25,6 @@ class FeedWriteViewModel @Inject constructor(
     }
 
     fun removeImgList(position: Int) {
-        Timber.d("4")
         val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!
 
         imgList.removeAt(position)

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -22,7 +22,6 @@ class FeedWriteViewModel @Inject constructor(
     fun addImgList(imgUri: List<Uri>) {
         val feedWriteImgList = imgUri.map { FeedWriteImg(it.toString()) }
         _testImgList.value!!.addAll(0, feedWriteImgList)
-        Timber.d("이미지 리스트: ${_testImgList.value}")
     }
 
     fun removeImgList(position: Int) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/main/MainActivity.kt
@@ -36,7 +36,8 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>(
             navController.addOnDestinationChangedListener { controller, destination, arguments ->
                 when(destination.id){
                     R.id.signupFragment, R.id.loginFragment, R.id.quizDailyOXFragment,
-                    R.id.quizDailyMultiChoiceFragment, R.id.feedWriteFragment -> bottomNavigationBar.visibility = View.INVISIBLE
+                    R.id.quizDailyMultiChoiceFragment, R.id.feedWriteFragment, R.id.feedDetailFragment,
+                    R.id.changeMyInfoFragment -> bottomNavigationBar.visibility = View.INVISIBLE
                     else -> bottomNavigationBar.visibility = View.VISIBLE
                 }
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/main/MainActivity.kt
@@ -35,7 +35,8 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>(
         binding.apply {
             navController.addOnDestinationChangedListener { controller, destination, arguments ->
                 when(destination.id){
-                    R.id.signupFragment, R.id.loginFragment, R.id.quizDailyOXFragment, R.id.quizDailyMultiChoiceFragment -> bottomNavigationBar.visibility = View.INVISIBLE
+                    R.id.signupFragment, R.id.loginFragment, R.id.quizDailyOXFragment,
+                    R.id.quizDailyMultiChoiceFragment, R.id.feedWriteFragment -> bottomNavigationBar.visibility = View.INVISIBLE
                     else -> bottomNavigationBar.visibility = View.VISIBLE
                 }
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreFragment.kt
@@ -15,8 +15,6 @@ class MoreFragment: BaseFragment<FragmentMoreBinding, MoreViewModel> (
     override val viewModel: MoreViewModel by viewModels()
 
     override fun initView() {
-        val bottomNavigationViewMainActivity = requireActivity().findViewById<BottomNavigationView>(R.id.bottom_navigation_bar)
-        bottomNavigationViewMainActivity.isVisible = true
 
         binding.apply {
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -27,8 +27,6 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
     private lateinit var phoneNumber: String
 
     override fun initView() {
-        val bottomNavigationViewMainActivity = requireActivity().findViewById<BottomNavigationView>(R.id.bottom_navigation_bar)
-        bottomNavigationViewMainActivity.isVisible = false
 
         binding.apply {
             btnChangeMyInfoBack.setOnClickListener {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -47,7 +47,7 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                         s: CharSequence?,
                         start: Int,
                         count: Int,
-                        after: Int,
+                        after: Int
                     ) {
                         setColorStateWithInput(
                             InputState.ON,
@@ -60,7 +60,7 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                         s: CharSequence?,
                         start: Int,
                         before: Int,
-                        count: Int,
+                        count: Int
                     ) {
                         setColorStateWithInput(
                             InputState.ON,

--- a/presentation/src/main/res/drawable/background_solid_gray_06_radius_10.xml
+++ b/presentation/src/main/res/drawable/background_solid_gray_06_radius_10.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<item>
+    <shape>
+        <solid android:color="@color/Gray_06" />
+        <corners android:radius="10dp"/>
+        <stroke
+            android:width="1dp"
+        android:color="@color/Gray_03" />
+    </shape>
+</item>
+
+<!-- Image icon -->
+<item
+    android:drawable="@drawable/ic_btn_photo"
+    android:gravity="center" />
+</layer-list>

--- a/presentation/src/main/res/drawable/ic_btn_photo.xml
+++ b/presentation/src/main/res/drawable/ic_btn_photo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,17H18L14.25,12L11.25,16L9,13L6,17ZM4,21C3.45,21 2.979,20.804 2.587,20.412C2.195,20.02 1.999,19.549 2,19V7C2,6.45 2.196,5.979 2.588,5.587C2.98,5.195 3.451,4.999 4,5H7.15L9,3H15L16.85,5H20C20.55,5 21.021,5.196 21.413,5.588C21.805,5.98 22.001,6.451 22,7V19C22,19.55 21.804,20.021 21.412,20.413C21.02,20.805 20.549,21.001 20,21H4Z"
+      android:fillColor="#494949"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_close_circle.xml
+++ b/presentation/src/main/res/drawable/ic_close_circle.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M4,0L12,0A4,4 0,0 1,16 4L16,12A4,4 0,0 1,12 16L4,16A4,4 0,0 1,0 12L0,4A4,4 0,0 1,4 0z"
+      android:fillColor="#000000"
+      android:fillAlpha="0.7"/>
+  <path
+      android:pathData="M8,1.333C11.686,1.333 14.666,4.313 14.666,8C14.666,11.687 11.686,14.667 8,14.667C4.313,14.667 1.333,11.687 1.333,8C1.333,4.313 4.313,1.333 8,1.333ZM10.393,4.667L8,7.06L5.606,4.667L4.666,5.607L7.06,8L4.666,10.393L5.606,11.333L8,8.94L10.393,11.333L11.333,10.393L8.94,8L11.333,5.607L10.393,4.667Z"
+      android:fillColor="#A2A2A2"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_feed_detail.xml
+++ b/presentation/src/main/res/layout/fragment_feed_detail.xml
@@ -11,277 +11,299 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="70dp"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_feed_detail"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_feed_detail_back"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="16dp"
-                    android:background="@drawable/ic_back"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/iv_feed_detail_user_profile"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
-                    android:layout_marginTop="16dp"
-                    android:src="@drawable/ic_user_base_profile"
-                    android:scaleType="centerCrop"
-                    app:shapeAppearanceOverlay="@style/radius_24"
-                    app:layout_constraintStart_toStartOf="@id/btn_feed_detail_back"
-                    app:layout_constraintTop_toBottomOf="@+id/btn_feed_detail_back" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_user_nickname"
-                    style="@style/H4"
-                    android:layout_width="wrap_content"
-                    android:layout_height="28dp"
-                    android:layout_marginStart="16dp"
-                    android:text="@string/test_nickname"
-                    app:layout_constraintStart_toEndOf="@id/iv_feed_detail_user_profile"
-                    app:layout_constraintTop_toTopOf="@+id/iv_feed_detail_user_profile" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_posting_time"
-                    style="@style/L1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="18dp"
-                    android:layout_marginStart="15dp"
-                    android:layout_marginTop="2dp"
-                    android:text="@string/test_posting_time"
-                    android:textColor="@color/Gray_05"
-                    app:layout_constraintStart_toEndOf="@id/iv_feed_detail_user_profile"
-                    app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_user_nickname" />
-
-                <ImageView
-                    android:id="@+id/iv_feed_detail_property"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_marginTop="62dp"
-                    android:layout_marginEnd="20dp"
-                    android:src="@drawable/ic_menu_option"
-                    android:tint="@color/Gray_05"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:ignore="UseAppTint" />
-
-                <androidx.viewpager2.widget.ViewPager2
-                    android:id="@+id/viewpager_feed_detail_img"
-                    android:layout_width="match_parent"
-                    android:layout_height="240dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="16dp"
-                    android:layout_marginEnd="20dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_posting_time" />
-
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tablayout_feed_detail_indicator"
-                    android:layout_width="wrap_content"
-                    android:layout_height="10dp"
-                    android:layout_marginTop="10dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/viewpager_feed_detail_img"
-                    app:tabBackground="@drawable/selector_feed_image_indicator"
-                    app:tabGravity="center"
-                    app:tabIndicatorHeight="0dp" />
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_feed_detail_like"
-                    android:layout_width="28dp"
-                    android:layout_height="28dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="12dp"
-                    android:background="@drawable/ic_btn_like_off"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tablayout_feed_detail_indicator" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_like"
-                    style="@style/B2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="20dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginTop="4dp"
-                    android:text="@string/feed_post_like"
-                    app:layout_constraintStart_toEndOf="@id/btn_feed_detail_like"
-                    app:layout_constraintTop_toTopOf="@id/btn_feed_detail_like" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_like_cnt"
-                    style="@style/B2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="20dp"
-                    android:layout_marginStart="3dp"
-                    android:text="@string/test_feed_post_like_cnt"
-                    app:layout_constraintStart_toEndOf="@id/tv_feed_detail_like"
-                    app:layout_constraintTop_toTopOf="@id/tv_feed_detail_like" />
-
-                <TextView
-                    style="@style/B2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="20dp"
-                    android:text="@string/count"
-                    app:layout_constraintStart_toEndOf="@id/tv_feed_detail_like_cnt"
-                    app:layout_constraintTop_toTopOf="@id/tv_feed_detail_like_cnt" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_title"
-                    style="@style/H4"
-                    android:layout_width="wrap_content"
-                    android:layout_height="28dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/test_feed_post_title"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/btn_feed_detail_like" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_content"
-                    style="@style/B2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="6dp"
-                    android:layout_marginEnd="20dp"
-                    android:text="@string/test_feed_post_content"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_feed_detail_title" />
-
-                <TextView
-                    style="@style/L1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="18dp"
-                    android:layout_marginEnd="3dp"
-                    android:text="@string/feed_reply"
-                    android:textColor="@color/Gray_01"
-                    app:layout_constraintEnd_toStartOf="@id/tv_feed_detail_reply_cnt"
-                    app:layout_constraintTop_toTopOf="@id/tv_feed_detail_reply_text" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_reply_cnt"
-                    style="@style/L1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="18dp"
-                    android:text="@string/test_feed_post_reply_cnt"
-                    android:textColor="@color/Gray_01"
-                    app:layout_constraintEnd_toStartOf="@id/tv_feed_detail_reply_text"
-                    app:layout_constraintTop_toTopOf="@id/tv_feed_detail_reply_text" />
-
-                <TextView
-                    android:id="@+id/tv_feed_detail_reply_text"
-                    style="@style/L1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="18dp"
-                    android:layout_marginTop="24dp"
-                    android:layout_marginEnd="20dp"
-                    android:text="@string/count"
-                    android:textColor="@color/Gray_01"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_content" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_feed_detail_reply"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_reply_text" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </androidx.core.widget.NestedScrollView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/cardview_feed_comment_writing_msg"
-            android:layout_width="match_parent"
-            android:layout_height="24dp"
-            android:layout_marginBottom="8dp"
-            android:visibility="gone"
-            app:cardBackgroundColor="@color/Gray_06"
-            app:layout_constraintBottom_toTopOf="@id/cardview_feed_reply">
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <TextView
-                    style="@style/l4"
-                    android:layout_width="wrap_content"
-                    android:layout_height="14dp"
-                    android:layout_marginStart="20dp"
-                    android:layout_marginTop="5dp"
-                    android:text="댓글을 남기는 중..."
-                    android:textColor="@color/Gray_04"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_feed_comment_writing_close"
-                    android:layout_width="16dp"
-                    android:layout_height="16dp"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="20dp"
-                    android:background="@drawable/ic_btn_close"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </androidx.cardview.widget.CardView>
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/cardview_feed_reply"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:layout_margin="20dp"
-            app:cardCornerRadius="10dp"
-            app:cardElevation="0dp"
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_feed_detail_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:indeterminate="true"
+            app:indicatorColor="@color/Blue_02"
+            app:indicatorSize="36dp"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:strokeColor="@color/Gray_03"
-            app:strokeWidth="1dp">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:trackThickness="5dp" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_feed_detail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="@color/White_01">
+                android:layout_marginBottom="70dp"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
-                <EditText
-                    android:id="@+id/edt_feed_detail_reply"
-                    style="@style/B2"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/btn_feed_detail_back"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="16dp"
+                        android:background="@drawable/ic_back"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/iv_feed_detail_user_profile"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:layout_marginTop="16dp"
+                        android:src="@drawable/ic_user_base_profile"
+                        android:scaleType="centerCrop"
+                        app:shapeAppearanceOverlay="@style/radius_24"
+                        app:layout_constraintStart_toStartOf="@id/btn_feed_detail_back"
+                        app:layout_constraintTop_toBottomOf="@+id/btn_feed_detail_back" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_user_nickname"
+                        style="@style/H4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="28dp"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/test_nickname"
+                        app:layout_constraintStart_toEndOf="@id/iv_feed_detail_user_profile"
+                        app:layout_constraintTop_toTopOf="@+id/iv_feed_detail_user_profile" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_posting_time"
+                        style="@style/L1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="18dp"
+                        android:layout_marginStart="15dp"
+                        android:layout_marginTop="2dp"
+                        android:text="@string/test_posting_time"
+                        android:textColor="@color/Gray_05"
+                        app:layout_constraintStart_toEndOf="@id/iv_feed_detail_user_profile"
+                        app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_user_nickname" />
+
+                    <ImageView
+                        android:id="@+id/iv_feed_detail_property"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginTop="62dp"
+                        android:layout_marginEnd="20dp"
+                        android:src="@drawable/ic_menu_option"
+                        android:tint="@color/Gray_05"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:ignore="UseAppTint" />
+
+                    <androidx.viewpager2.widget.ViewPager2
+                        android:id="@+id/viewpager_feed_detail_img"
+                        android:layout_width="match_parent"
+                        android:layout_height="240dp"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="16dp"
+                        android:layout_marginEnd="20dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_posting_time" />
+
+                    <com.google.android.material.tabs.TabLayout
+                        android:id="@+id/tablayout_feed_detail_indicator"
+                        android:layout_width="wrap_content"
+                        android:layout_height="10dp"
+                        android:layout_marginTop="10dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/viewpager_feed_detail_img"
+                        app:tabBackground="@drawable/selector_feed_image_indicator"
+                        app:tabGravity="center"
+                        app:tabIndicatorHeight="0dp" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/btn_feed_detail_like"
+                        android:layout_width="28dp"
+                        android:layout_height="28dp"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="12dp"
+                        android:background="@drawable/ic_btn_like_off"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tablayout_feed_detail_indicator" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_like"
+                        style="@style/B2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:layout_marginStart="8dp"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/feed_post_like"
+                        app:layout_constraintStart_toEndOf="@id/btn_feed_detail_like"
+                        app:layout_constraintTop_toTopOf="@id/btn_feed_detail_like" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_like_cnt"
+                        style="@style/B2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:layout_marginStart="3dp"
+                        android:text="@string/test_feed_post_like_cnt"
+                        app:layout_constraintStart_toEndOf="@id/tv_feed_detail_like"
+                        app:layout_constraintTop_toTopOf="@id/tv_feed_detail_like" />
+
+                    <TextView
+                        style="@style/B2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:text="@string/count"
+                        app:layout_constraintStart_toEndOf="@id/tv_feed_detail_like_cnt"
+                        app:layout_constraintTop_toTopOf="@id/tv_feed_detail_like_cnt" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_title"
+                        style="@style/H4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="28dp"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="16dp"
+                        android:text="@string/test_feed_post_title"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/btn_feed_detail_like" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_content"
+                        style="@style/B2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="6dp"
+                        android:layout_marginEnd="20dp"
+                        android:text="@string/test_feed_post_content"
+                        app:layout_constraintTop_toBottomOf="@+id/tv_feed_detail_title" />
+
+                    <TextView
+                        style="@style/L1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="18dp"
+                        android:layout_marginEnd="3dp"
+                        android:text="@string/feed_reply"
+                        android:textColor="@color/Gray_01"
+                        app:layout_constraintEnd_toStartOf="@id/tv_feed_detail_reply_cnt"
+                        app:layout_constraintTop_toTopOf="@id/tv_feed_detail_reply_text" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_reply_cnt"
+                        style="@style/L1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="18dp"
+                        android:text="@string/test_feed_post_reply_cnt"
+                        android:textColor="@color/Gray_01"
+                        app:layout_constraintEnd_toStartOf="@id/tv_feed_detail_reply_text"
+                        app:layout_constraintTop_toTopOf="@id/tv_feed_detail_reply_text" />
+
+                    <TextView
+                        android:id="@+id/tv_feed_detail_reply_text"
+                        style="@style/L1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="18dp"
+                        android:layout_marginTop="24dp"
+                        android:layout_marginEnd="20dp"
+                        android:text="@string/count"
+                        android:textColor="@color/Gray_01"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_content" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_feed_detail_reply"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                        app:layout_constraintTop_toBottomOf="@id/tv_feed_detail_reply_text" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </androidx.core.widget.NestedScrollView>
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/cardview_feed_comment_writing_msg"
+                android:layout_width="match_parent"
+                android:layout_height="24dp"
+                android:layout_marginBottom="8dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/Gray_06"
+                app:layout_constraintBottom_toTopOf="@id/cardview_feed_reply">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        style="@style/l4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="14dp"
+                        android:layout_marginStart="20dp"
+                        android:layout_marginTop="5dp"
+                        android:text="댓글을 남기는 중..."
+                        android:textColor="@color/Gray_04"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/btn_feed_comment_writing_close"
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        android:layout_marginTop="4dp"
+                        android:layout_marginEnd="20dp"
+                        android:background="@drawable/ic_btn_close"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </androidx.cardview.widget.CardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardview_feed_reply"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_margin="20dp"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:strokeColor="@color/Gray_03"
+                app:strokeWidth="1dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginStart="26dp"
-                    android:layout_marginEnd="35dp"
-                    android:background="@color/White_01"
-                    android:hint="@string/feed_detail_comment_msg"
-                    android:textColorHint="@color/Gray_05" />
+                    android:background="@color/White_01">
 
-                <androidx.appcompat.widget.AppCompatButton
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:layout_marginTop="15dp"
-                    android:layout_marginEnd="15dp"
-                    android:background="@drawable/ic_btn_reply_write"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    <EditText
+                        android:id="@+id/edt_feed_detail_reply"
+                        style="@style/B2"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginStart="26dp"
+                        android:layout_marginEnd="35dp"
+                        android:background="@color/White_01"
+                        android:hint="@string/feed_detail_comment_msg"
+                        android:textColorHint="@color/Gray_05" />
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_marginTop="15dp"
+                        android:layout_marginEnd="15dp"
+                        android:background="@drawable/ic_btn_reply_write"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-        </com.google.android.material.card.MaterialCardView>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>
+

--- a/presentation/src/main/res/layout/fragment_feed_total.xml
+++ b/presentation/src/main/res/layout/fragment_feed_total.xml
@@ -7,12 +7,26 @@
 
     </data>
 
-    <FrameLayout
-        android:id="@+id/layout_feed"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_feed_total_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:indeterminate="true"
+            app:indicatorColor="@color/Blue_02"
+            app:indicatorSize="36dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:trackThickness="5dp" />
+
         <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/layout_feed"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -95,6 +109,6 @@
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/presentation/src/main/res/layout/fragment_feed_write.xml
+++ b/presentation/src/main/res/layout/fragment_feed_write.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="피드 작성"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_feed_write.xml
+++ b/presentation/src/main/res/layout/fragment_feed_write.xml
@@ -70,7 +70,7 @@
             android:layout_width="0dp"
             android:layout_height="60dp"
             android:orientation="horizontal"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="@+id/btn_feed_write_add_photo"
             app:layout_constraintStart_toEndOf="@+id/btn_feed_write_add_photo"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/layout/fragment_feed_write.xml
+++ b/presentation/src/main/res/layout/fragment_feed_write.xml
@@ -73,6 +73,7 @@
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="@+id/btn_feed_write_add_photo"
             app:layout_constraintStart_toEndOf="@+id/btn_feed_write_add_photo"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/btn_feed_write_add_photo" />
 
         <androidx.appcompat.widget.AppCompatButton

--- a/presentation/src/main/res/layout/fragment_feed_write.xml
+++ b/presentation/src/main/res/layout/fragment_feed_write.xml
@@ -65,10 +65,10 @@
             app:layout_constraintStart_toStartOf="parent" />
 
         <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_feed_write_upload_img"
             tools:listitem="@layout/item_feed_write_img"
             android:layout_width="0dp"
             android:layout_height="60dp"
-            android:layout_marginStart="16dp"
             android:orientation="horizontal"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="@+id/btn_feed_write_add_photo"

--- a/presentation/src/main/res/layout/fragment_feed_write.xml
+++ b/presentation/src/main/res/layout/fragment_feed_write.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -8,16 +9,84 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="피드 작성"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_feed_write_back"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/ic_back"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/edt_feed_write_title"
+            style="@style/b1"
+            android:layout_width="match_parent"
+            android:layout_height="44dp"
+            android:layout_marginTop="20dp"
+            android:background="@drawable/selector_signup_nickname"
+            android:hint="@string/feed_write_title"
+            android:inputType="text"
+            android:padding="10dp"
+            android:textColorHint="@color/Gray_05"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_feed_write_back" />
+
+        <EditText
+            android:id="@+id/edt_feed_write_content"
+            style="@style/b1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="24dp"
+            android:background="@drawable/selector_signup_nickname"
+            android:gravity="top|start"
+            android:hint="@string/feed_write_content"
+            android:inputType="textMultiLine"
+            android:padding="10dp"
+            android:textColorHint="@color/Gray_05"
+            app:layout_constraintBottom_toTopOf="@id/btn_feed_write_add_photo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/edt_feed_write_title" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_feed_write_add_photo"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginBottom="24dp"
+            android:background="@drawable/background_solid_gray_06_radius_10"
+            app:layout_constraintBottom_toTopOf="@+id/btn_feed_write_confirm"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            tools:listitem="@layout/item_feed_write_img"
+            android:layout_width="0dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="16dp"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_feed_write_add_photo"
+            app:layout_constraintStart_toEndOf="@+id/btn_feed_write_add_photo"
+            app:layout_constraintTop_toTopOf="@+id/btn_feed_write_add_photo" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_feed_write_confirm"
+            style="@style/Button1"
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:layout_marginBottom="17dp"
+            android:background="@drawable/background_solid_blue_01_radius_15"
+            android:text="@string/quiz_dialog_confirm"
+            android:textColor="@color/White_01"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_feed_write_img.xml
+++ b/presentation/src/main/res/layout/item_feed_write_img.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="60dp"
+        android:layout_height="60dp">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_feed_write_img"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            app:shapeAppearanceOverlay="@style/radius_10"/>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:background="@drawable/ic_close_circle"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="6dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_feed_write_img.xml
+++ b/presentation/src/main/res/layout/item_feed_write_img.xml
@@ -19,6 +19,7 @@
             app:shapeAppearanceOverlay="@style/radius_10"/>
 
         <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_remove_upload_img"
             android:layout_width="16dp"
             android:layout_height="16dp"
             android:background="@drawable/ic_close_circle"

--- a/presentation/src/main/res/layout/item_feed_write_img.xml
+++ b/presentation/src/main/res/layout/item_feed_write_img.xml
@@ -7,13 +7,14 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="60dp"
+        android:layout_width="76dp"
         android:layout_height="60dp">
 
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/iv_feed_write_img"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
             android:scaleType="centerCrop"
             app:shapeAppearanceOverlay="@style/radius_10"/>
 

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -12,9 +12,7 @@
         tools:layout="@layout/fragment_feed_total" >
         <action
             android:id="@+id/action_feedTotalFragment_to_feedDetailFragment"
-            app:destination="@id/feedDetailFragment"
-            app:enterAnim="@anim/fragment_enter_anim"
-            app:popEnterAnim="@anim/fragment_pop_enter_anim" />
+            app:destination="@id/feedDetailFragment" />
         <action
             android:id="@+id/action_navigation_feed_to_feedWriteFragment"
             app:destination="@id/feedWriteFragment" />

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -15,6 +15,9 @@
             app:destination="@id/feedDetailFragment"
             app:enterAnim="@anim/fragment_enter_anim"
             app:popEnterAnim="@anim/fragment_pop_enter_anim" />
+        <action
+            android:id="@+id/action_navigation_feed_to_feedWriteFragment"
+            app:destination="@id/feedWriteFragment" />
     </fragment>
     <fragment
         android:id="@+id/feedDetailFragment"
@@ -27,6 +30,15 @@
         <argument
             android:name="feedId"
             app:argType="integer" />
+    </fragment>
+    <fragment
+        android:id="@+id/feedWriteFragment"
+        android:name="com.shypolarbear.presentation.ui.feed.feedWrite.FeedWriteFragment"
+        android:label="FeedWriteFragment"
+        tools:layout="@layout/fragment_feed_write">
+        <action
+            android:id="@+id/action_feedWriteFragment_to_navigation_feed"
+            app:destination="@id/navigation_feed" />
     </fragment>
     <fragment
         android:id="@+id/signupFragment"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -108,5 +108,6 @@
 
     <string name="feed_write_title_msg">제목을 입력해주세요!</string>
     <string name="feed_write_content_msg">내용을 입력해주세요!</string>
+    <string name="feed_write_image_count_msg">이미지는 최대 5장까지 업로드 가능합니다.</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -106,4 +106,7 @@
     <string name="check_my_info_term">조건에 맞게 다시 입력해주세요!</string>
     <string name="check_my_info_input">수정할 정보를 입력해주세요!</string>
 
+    <string name="feed_write_title_msg">제목을 입력해주세요!</string>
+    <string name="feed_write_content_msg">내용을 입력해주세요!</string>
+
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -100,5 +100,7 @@
     <string name="quiz_dialog_yes">네</string>
     <string name="quiz_dialog_no">아니오</string>
     <string name="quiz_main_polarbear">북극곰</string>
+    <string name="feed_write_title">제목 입력</string>
+    <string name="feed_write_content">내용 입력</string>
 
 </resources>


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 피드 작성 UI 구현
- 피드 전체 조회에서 피드 작성으로 이동 구현
- PickVisualMediaRequest 사용하여 갤러리 내의 이미지를 uri 리스트로 받아오게 구현
- x버튼 누르면 업로드할 이미지를 리스트에서 제거
- 추가) 피드 전체 조회, 상세 조회 시 데이터 받아오는 동안 Progress bar 보이게 처리

🌱 PR 포인트
- 피드 작성 UI 및 피드 전체 조회 화면과 연결을 구현하였습니다. 화면 죄측 상단의 < 버튼 클릭 시 이전 화면으로 이동하게 하였고, 제목과 내용 중 하나라도 빈 값이 있는 경우 게시물 작성되서 이전 화면으로 이동하지 못하게 하였습니다.
- PickVisualMediaRequest를 사용하여 갤러리 내의 이미지를 업로드할 수 있게 하였습니다. 한 번에 여러 장을 업로드 할 수 있게 하였고, 한 번에 최대 5장까지 선택할 수 있게 하였습니다. 추가로 선택한 이미지가 이미 5장인 경우, 이미 선택된 이미지에 추가로 선택한 이미지가 5장이 넘어가는 경우에는 토스트 메시지를 띄우면서 이미지를 리스트에 넣지 못하게 했습니다.

- 데이터 받아오는 동안 Progress bar를 보이게 처리하였는데 Progress bar의 디자인은 피그마의 디자인 가이드 Input Box의 Loading에 있는 것을 참고하였습니다. 실기기에서 테스트 해본 결과 화면에 비해 Progress bar가 너무 작다고 판단되어 크기와 두께를 임의로 수정하여 적용하였습니다.
**Figma의 디자인 크기: 24dp**
**적용 크기: 36dp**

## 📸 스크린샷
|스크린샷|
https://github.com/ShyPolarBear/Android/assets/107917980/2cc4671b-d690-45de-af27-61a615f98970
(에뮬레이터에서는 PickVisualMediaRequest의 PickMultipleVisualMedia모드가 실행이 안되서 실기기로 테스트했슴다 ㅎㅎ)

https://github.com/ShyPolarBear/Android/assets/107917980/e8bc0ab9-145f-47bf-bd38-4afa491ad157
ProgressBar 테스트 영상

## 📮 관련 이슈
- Resolved: #54 
