### PR TITLE
[WBS-200]Feature/add feed change UI

### DIFF
--- a/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
@@ -36,8 +36,8 @@ object AuthNetworkModule {
     ): Retrofit {
 
         return Retrofit.Builder()
-            .baseUrl(BASE_URL)
-//            .baseUrl(MOCK_URL)
+//            .baseUrl(BASE_URL)
+            .baseUrl(MOCK_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .client(client)
             .build()

--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -15,6 +15,7 @@ import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.domain.usecase.LoginUseCase
 import com.shypolarbear.domain.usecase.tokens.GetRefreshTokenUseCase
 import com.shypolarbear.domain.usecase.TokenRenewUseCase
+import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.domain.usecase.more.ChangeMyInfoUseCase
@@ -112,5 +113,11 @@ class UseCaseModule {
     @Provides
     fun provideQuizUseCase(repo: QuizRepo): QuizUseCase{
         return QuizUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideChangePostUseCase(repo: FeedRepo): ChangePostUseCase {
+        return ChangePostUseCase(repo)
     }
 }

--- a/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
@@ -1,10 +1,14 @@
 package com.shypolarbear.data.api.feed
 
 import com.shypolarbear.domain.model.feed.FeedTotal
+import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface FeedApi {
@@ -15,6 +19,13 @@ interface FeedApi {
     suspend fun getFeedDetail(
         @Path("feedId") feedID: Int
     ): Response<FeedDetail>
+
+    @PUT("api/feeds/{feedId}")
+    suspend fun requestChangePost(
+        @Path("feedId") feedID: Int,
+        @Body
+        writeFeedForm: WriteFeedForm
+    ): Response<ChangePostResponse>
 
     @GET("api/feeds/{feedId}/comment")
     suspend fun getFeedComment(

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
@@ -3,6 +3,8 @@ package com.shypolarbear.data.repositoryimpl.feed
 import com.shypolarbear.data.api.feed.FeedApi
 import com.shypolarbear.domain.model.HttpError
 import com.shypolarbear.domain.model.feed.FeedTotal
+import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
 import com.shypolarbear.domain.repository.feed.FeedRepo
@@ -46,6 +48,35 @@ class FeedRepoImpl @Inject constructor(
     override suspend fun getFeedCommentData(feedId: Int): Result<FeedComment> {
         return try {
             val response = api.getFeedComment(feedId)
+            when {
+                response.isSuccessful -> {
+                    Result.success(response.body()!!)
+                }
+                else -> {
+                    Result.failure(HttpError(response.code(), response.errorBody()?.string() ?: ""))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun requestChangePost(
+        feedId: Int,
+        content: String,
+        feedImages: List<String>?,
+        title: String
+    ): Result<ChangePostResponse> {
+        return try {
+            val response = api.requestChangePost(
+                feedId,
+                WriteFeedForm(
+                    content = content,
+                    feedId = feedId,
+                    feedImages = listOf("NULL"),  // TODO("이미지 작업 완료되면 수정할 예정")
+                    title = title
+                )
+            )
             when {
                 response.isSuccessful -> {
                     Result.success(response.body()!!)

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/ChangePostResponse.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/ChangePostResponse.kt
@@ -1,0 +1,7 @@
+package com.shypolarbear.domain.model.feed.feedChange
+
+data class ChangePostResponse(
+    val code: Int,
+    val data : FeedId,
+    val message: String
+)

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/FeedId.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/FeedId.kt
@@ -1,0 +1,5 @@
+package com.shypolarbear.domain.model.feed.feedChange
+
+data class FeedId(
+    val feedId: Int
+)

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/WriteFeedForm.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/WriteFeedForm.kt
@@ -1,0 +1,8 @@
+package com.shypolarbear.domain.model.feed.feedChange
+
+data class WriteFeedForm(
+    val content: String,
+    val feedId: Int,
+    val feedImages: List<String>?,
+    val title: String
+)

--- a/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
@@ -1,6 +1,7 @@
 package com.shypolarbear.domain.repository.feed
 
 import com.shypolarbear.domain.model.feed.FeedTotal
+import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
 
@@ -10,4 +11,11 @@ interface FeedRepo {
     suspend fun getFeedDetailData(feedId: Int): Result<FeedDetail>
 
     suspend fun getFeedCommentData(feedId: Int): Result<FeedComment>
+
+    suspend fun requestChangePost(
+        feedId: Int,
+        content: String,
+        feedImages: List<String>?,
+        title: String
+    ): Result<ChangePostResponse>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/ChangePostUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/ChangePostUseCase.kt
@@ -1,0 +1,17 @@
+package com.shypolarbear.domain.usecase.feed
+
+import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.repository.feed.FeedRepo
+
+class ChangePostUseCase (
+    private val repo: FeedRepo
+) {
+    suspend fun requestChangePost(
+        feedId: Int,
+        content: String,
+        feedImages: List<String>?,
+        title: String
+    ): Result<ChangePostResponse> {
+        return repo.requestChangePost(feedId, content, feedImages, title)
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -7,7 +7,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedTotalBinding
@@ -18,7 +17,11 @@ import com.shypolarbear.presentation.util.setMenu
 import com.skydoves.powermenu.PowerMenuItem
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import timber.log.Timber
+
+enum class WriteChangeDivider(val fragmentType: Int) {
+    WRITE(0),
+    CHANGE(1)
+}
 
 @AndroidEntryPoint
 class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewModel> (
@@ -32,8 +35,8 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
 
     override val viewModel: FeedTotalViewModel by viewModels()
     private val feedPostAdapter = FeedPostAdapter(
-        onMyPostPropertyClick = { view: ImageView ->
-            showMyPostPropertyMenu(view)
+        onMyPostPropertyClick = { view: ImageView, feedId: Int ->
+            showMyPostPropertyMenu(view, feedId)
         },
         onOtherPostPropertyClick = { view: ImageView ->
             showOtherPostPropertyMenu(view)
@@ -80,7 +83,11 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
             }
 
             btnFeedPostWrite.setOnClickListener {
-                findNavController().navigate(R.id.action_navigation_feed_to_feedWriteFragment)
+                findNavController().navigate(
+                    FeedTotalFragmentDirections.actionNavigationFeedToFeedWriteFragment(
+                        WriteChangeDivider.WRITE, 0
+                    )
+                )
             }
             setFeedPost()
         }
@@ -97,7 +104,7 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         }
     }
 
-    private fun showMyPostPropertyMenu(view: ImageView) {
+    private fun showMyPostPropertyMenu(view: ImageView, feedId: Int) {
         val myCommentPropertyItems: List<PowerMenuItem> =
             listOf(
                 PowerMenuItem(requireContext().getString(R.string.feed_post_property_revise)),
@@ -111,7 +118,11 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         ) { _, item ->
             when(item.title) {
                 getString(R.string.feed_post_property_revise) -> {
-                    findNavController().navigate(R.id.action_navigation_feed_to_feedWriteFragment)
+                    findNavController().navigate(
+                        FeedTotalFragmentDirections.actionNavigationFeedToFeedWriteFragment(
+                            WriteChangeDivider.CHANGE, feedId
+                        )
+                    )
                 }
                 getString(R.string.feed_post_property_delete) -> {
                     // TODO("게시뭏 삭제 클릭 시 동작")

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -12,6 +12,7 @@ import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedTotalBinding
 import com.shypolarbear.presentation.ui.feed.feedTotal.adapter.FeedPostAdapter
+import com.shypolarbear.presentation.util.PowerMenuUtil
 import com.shypolarbear.presentation.util.showLikeBtnIsLike
 import com.shypolarbear.presentation.util.setMenu
 import com.skydoves.powermenu.PowerMenuItem
@@ -103,10 +104,23 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                 PowerMenuItem(requireContext().getString(R.string.feed_post_property_delete))
             )
 
-        view.setMenu(
+        PowerMenuUtil.getPowerMenu(
+            requireContext(),
+            viewLifecycleOwner,
+            myCommentPropertyItems
+        ) { _, item ->
+            when(item.title) {
+                getString(R.string.feed_post_property_revise) -> {
+                    findNavController().navigate(R.id.action_navigation_feed_to_feedWriteFragment)
+                }
+                getString(R.string.feed_post_property_delete) -> {
+                    // TODO("게시뭏 삭제 클릭 시 동작")
+                }
+            }
+        }.showAsDropDown(
             view,
-            myCommentPropertyItems,
-            viewLifecycleOwner
+            POWER_MENU_OFFSET_X,
+            POWER_MENU_OFFSET_Y
         )
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
@@ -13,7 +13,7 @@ import com.shypolarbear.presentation.ui.feed.feedTotal.FeedTotalLikeBtnType
 import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedPostViewHolder
 
 class FeedPostAdapter(
-    private val onMyPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
+    private val onMyPostPropertyClick: (view: ImageView, feedId: Int) -> Unit = { _, _ -> },
     private val onOtherPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onMyBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onOtherBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
@@ -18,7 +18,7 @@ import timber.log.Timber
 
 class FeedPostViewHolder(
     private val binding: ItemFeedBinding,
-    private val onMyPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
+    private val onMyPostPropertyClick: (view: ImageView, feedId: Int) -> Unit = { _, _ -> },
     private val onOtherPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onMyBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onOtherBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
@@ -44,7 +44,7 @@ class FeedPostViewHolder(
         // 게시물 작성자 확인
         binding.ivFeedPostProperty.setOnClickListener {
             when(post.isAuthor) {
-                true -> onMyPostPropertyClick(binding.ivFeedPostProperty)
+                true -> onMyPostPropertyClick(binding.ivFeedPostProperty, post.feedId)
                 false -> onOtherPostPropertyClick(binding.ivFeedPostProperty)
             }
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -3,12 +3,15 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 import android.widget.Toast
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedWriteBinding
+import com.shypolarbear.presentation.ui.feed.feedTotal.WriteChangeDivider
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -22,6 +25,8 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 ) {
 
     override val viewModel: FeedWriteViewModel by viewModels()
+    private val feedWriteArgs: FeedWriteFragmentArgs by navArgs()
+
     private val feedWriteImgAdapter = FeedWriteImgAdapter(
         onRemoveImgClick = { position: Int -> removeImg(position) }
     )
@@ -43,6 +48,22 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
 
     override fun initView() {
         binding.apply {
+
+            when(feedWriteArgs.divider) {
+                WriteChangeDivider.WRITE -> {
+
+                }
+                WriteChangeDivider.CHANGE -> {
+                    viewModel.loadFeedDetail(feedWriteArgs.feedId)
+                    viewModel.feed.observe(viewLifecycleOwner) { feed ->
+                        edtFeedWriteTitle.setText(feed.title)
+                        edtFeedWriteContent.setText(feed.content)
+
+                        val imgUriList = feed.feedImage.map { it.toUri() }
+                        viewModel.addImgList(imgUriList)
+                    }
+                }
+            }
 
             rvFeedWriteUploadImg.adapter = feedWriteImgAdapter
             viewModel.liveImgList.observe(viewLifecycleOwner) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -87,6 +87,19 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                         Toast.makeText(requireContext(), getString(R.string.feed_write_content_msg), Toast.LENGTH_SHORT).show()
                     }
                     else -> {
+                        when(feedWriteArgs.divider) {
+                            WriteChangeDivider.WRITE -> {
+
+                            }
+                            WriteChangeDivider.CHANGE -> {
+                                viewModel.changePost(
+                                    feedId = feedWriteArgs.feedId,
+                                    content = edtFeedWriteContent.text.toString(),
+                                    feedImages = null,
+                                    title = edtFeedWriteTitle.text.toString()
+                                )
+                            }
+                        }
                         findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
                     }
                 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
-    private val feedDetailUseCase: FeedDetailUseCase
+    private val feedDetailUseCase: FeedDetailUseCase,
+    private val changePostUseCase: ChangePostUseCase
 ): BaseViewModel(){
     private val _feed = MutableLiveData<Feed>()
     val feed: LiveData<Feed> = _feed
@@ -34,6 +36,12 @@ class FeedWriteViewModel @Inject constructor(
                 .onFailure {
 
                 }
+        }
+    }
+
+    fun changePost(feedId: Int, content: String, feedImages: List<String>?, title: String) {
+        viewModelScope.launch {
+            changePostUseCase.requestChangePost(feedId, content, feedImages, title)
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -3,18 +3,39 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
-
+    private val feedDetailUseCase: FeedDetailUseCase
 ): BaseViewModel(){
+    private val _feed = MutableLiveData<Feed>()
+    val feed: LiveData<Feed> = _feed
+
     private val _liveImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
     val liveImgList: LiveData<MutableList<FeedWriteImg>> = _liveImgList
+
+    fun loadFeedDetail(feedId: Int) {
+        viewModelScope.launch {
+            val feedDetailData = feedDetailUseCase.loadFeedDetailData(feedId)
+
+            feedDetailData
+                .onSuccess {
+                    _feed.value = it.data
+                }
+                .onFailure {
+
+                }
+        }
+    }
 
     fun addImgList(imgUri: List<Uri>) {
         val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
@@ -220,6 +220,7 @@ fun EditText.keyboardDown(fragment: Fragment) {
     }
 }
 
+// TODO("클릭 동작 수행하기 위해서는 공통으로 사용할 수 없을 듯 API 연동하면서 제거 해야 할 듯;")
 fun ImageView.setMenu(
     view: ImageView,
     menuList: List<PowerMenuItem>,
@@ -229,7 +230,8 @@ fun ImageView.setMenu(
         context,
         viewLifecycleOwner,
         menuList
-    ).showAsDropDown(
+    ) { _, _ -> }
+        .showAsDropDown(
         view,
         FeedTotalFragment.POWER_MENU_OFFSET_X,
         FeedTotalFragment.POWER_MENU_OFFSET_Y

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/PowerMenuUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/PowerMenuUtil.kt
@@ -2,6 +2,7 @@ package com.shypolarbear.presentation.util
 
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
+import com.skydoves.powermenu.OnMenuItemClickListener
 import com.skydoves.powermenu.PowerMenu
 import com.skydoves.powermenu.PowerMenuItem
 import com.skydoves.powermenu.kotlin.createPowerMenu
@@ -16,7 +17,8 @@ object PowerMenuUtil {
     fun getPowerMenu(
         context: Context,
         lifecycle: LifecycleOwner,
-        items: List<PowerMenuItem>
+        items: List<PowerMenuItem>,
+        onItemClickListener: OnMenuItemClickListener<PowerMenuItem>
     ): PowerMenu {
         return createPowerMenu(context) {
             addItemList(items)
@@ -26,6 +28,7 @@ object PowerMenuUtil {
             setPadding(MENU_PADDING)
             setLifecycleOwner(lifecycle)
             setAutoDismiss(true)
+            setOnMenuItemClickListener(onItemClickListener)
             build()
         }
     }

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -37,6 +37,13 @@
         <action
             android:id="@+id/action_feedWriteFragment_to_navigation_feed"
             app:destination="@id/navigation_feed" />
+        <argument
+            android:name="divider"
+            app:argType="com.shypolarbear.presentation.ui.feed.feedTotal.WriteChangeDivider" />
+        <argument
+            android:name="feedId"
+            app:argType="integer" />
+
     </fragment>
     <fragment
         android:id="@+id/signupFragment"


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 피드 수정 기능 구현

🌱 PR 포인트
- 피드 수정을 위해서는 PowerMenu에 클릭 이벤트를 감지해야 하는데 기존에 FunctionUtil에 확장 함수로 정의한 ImageView.setMenu 함수를 사용하면 각 아이템에 대한 클릭 이벤트를 따로 구현할 수 없다고 판단되어 fragment에서 확장 함수를 사용하지 않고 수정 클릭 시 피드 작성 화면으로 전환되게 하였습니다.

- 피드 작성 화면으로 전환 시 피드 작성/수정을 구분하기 위한 값과 feed id를 받게 하였습니다. 구분자를 통해서 피드 작성인지 수정인지 판단하고 수정이면 feed id를 이용하여 피드 상세 조회 요청을 하게 하였습니다. 이를 통해 받아온 피드 정보를 초기 값으로 보이게 하였습니다.

- 피드 작성 클릭 시에도 구분자를 통해서 작성/수정을 구분하여 올바른 동작을 수행하도록 정의하였습니다.

## 📸 스크린샷
|스크린샷|
https://github.com/ShyPolarBear/Android/assets/107917980/8ca5acc8-8012-4d64-a93f-6ec2f69724e7

## 📮 관련 이슈
- Resolved: #62 
