### PR TITLE
[WBS-204]Feature/apply feed write delete api

### DIFF
--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -19,6 +19,7 @@ import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
+import com.shypolarbear.domain.usecase.feed.FeedWriteUseCase
 import com.shypolarbear.domain.usecase.more.ChangeMyInfoUseCase
 import com.shypolarbear.domain.usecase.quiz.QuizUseCase
 import com.shypolarbear.domain.usecase.tokens.SetAccessTokenUseCase
@@ -126,5 +127,11 @@ class UseCaseModule {
     @Provides
     fun provideFeedDeleteUseCase(repo: FeedRepo): FeedDeleteUseCase {
         return FeedDeleteUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideFeedWriteUseCase(repo: FeedRepo): FeedWriteUseCase {
+        return FeedWriteUseCase(repo)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -17,6 +17,7 @@ import com.shypolarbear.domain.usecase.tokens.GetRefreshTokenUseCase
 import com.shypolarbear.domain.usecase.TokenRenewUseCase
 import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
+import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.domain.usecase.more.ChangeMyInfoUseCase
 import com.shypolarbear.domain.usecase.quiz.QuizUseCase
@@ -119,5 +120,11 @@ class UseCaseModule {
     @Provides
     fun provideChangePostUseCase(repo: FeedRepo): ChangePostUseCase {
         return ChangePostUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideFeedDeleteUseCase(repo: FeedRepo): FeedDeleteUseCase {
+        return FeedDeleteUseCase(repo)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/UseCaseModule.kt
@@ -15,10 +15,11 @@ import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.domain.usecase.LoginUseCase
 import com.shypolarbear.domain.usecase.tokens.GetRefreshTokenUseCase
 import com.shypolarbear.domain.usecase.TokenRenewUseCase
-import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
+import com.shypolarbear.domain.usecase.feed.FeedChangeUseCase
 import com.shypolarbear.domain.usecase.feed.FeedCommentUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
+import com.shypolarbear.domain.usecase.feed.FeedLikeUseCase
 import com.shypolarbear.domain.usecase.feed.FeedWriteUseCase
 import com.shypolarbear.domain.usecase.more.ChangeMyInfoUseCase
 import com.shypolarbear.domain.usecase.quiz.QuizUseCase
@@ -119,8 +120,8 @@ class UseCaseModule {
 
     @Singleton
     @Provides
-    fun provideChangePostUseCase(repo: FeedRepo): ChangePostUseCase {
-        return ChangePostUseCase(repo)
+    fun provideChangePostUseCase(repo: FeedRepo): FeedChangeUseCase {
+        return FeedChangeUseCase(repo)
     }
 
     @Singleton
@@ -133,5 +134,11 @@ class UseCaseModule {
     @Provides
     fun provideFeedWriteUseCase(repo: FeedRepo): FeedWriteUseCase {
         return FeedWriteUseCase(repo)
+    }
+
+    @Singleton
+    @Provides
+    fun provideFeedLikeUseCase(repo: FeedRepo): FeedLikeUseCase {
+        return FeedLikeUseCase(repo)
     }
 }

--- a/app/src/main/java/com/shypolarbear/android/util/Constant.kt
+++ b/app/src/main/java/com/shypolarbear/android/util/Constant.kt
@@ -2,5 +2,5 @@ package com.shypolarbear.android.util
 
 const val BASE_URL = "http://3.37.80.247:8080/"
 const val SAMPLE_URL = "https://api.chucknorris.io/"
-const val MOCK_URL = "https://ec4049d6-e0e0-494c-a4bc-638ad060740c.mock.pstmn.io"
+const val MOCK_URL = "https://ed3bf92e-bc49-483f-85b9-c042456779e9.mock.pstmn.io"
 const val RETROFIT_TAG = "Retrofit Tag"

--- a/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
@@ -9,6 +9,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 
@@ -36,5 +37,11 @@ interface FeedApi {
     @DELETE("api/feeds/{feedId}")
     suspend fun deleteFeed(
         @Path("feedId") feedID: Int
+    ): Response<FeedChangeResponse>
+
+    @POST("api/feeds")
+    suspend fun writeFeed(
+        @Body
+        writeFeedForm: WriteFeedForm
     ): Response<FeedChangeResponse>
 }

--- a/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
@@ -1,12 +1,13 @@
 package com.shypolarbear.data.api.feed
 
 import com.shypolarbear.domain.model.feed.FeedTotal
-import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -25,10 +26,15 @@ interface FeedApi {
         @Path("feedId") feedID: Int,
         @Body
         writeFeedForm: WriteFeedForm
-    ): Response<ChangePostResponse>
+    ): Response<FeedChangeResponse>
 
     @GET("api/feeds/{feedId}/comment")
     suspend fun getFeedComment(
         @Path("feedId") feedID: Int
     ): Response<FeedComment>
+
+    @DELETE("api/feeds/{feedId}")
+    suspend fun deleteFeed(
+        @Path("feedId") feedID: Int
+    ): Response<FeedChangeResponse>
 }

--- a/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
+++ b/data/src/main/java/com/shypolarbear/data/api/feed/FeedApi.kt
@@ -5,6 +5,7 @@ import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
+import com.shypolarbear.domain.model.feed.feedLike.FeedLikeResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -44,4 +45,9 @@ interface FeedApi {
         @Body
         writeFeedForm: WriteFeedForm
     ): Response<FeedChangeResponse>
+
+    @PUT("api/feeds/{feedId}/like")
+    suspend fun likeFeed(
+        @Path("feedId") feedID: Int
+    ): Response<FeedLikeResponse>
 }

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
@@ -7,6 +7,7 @@ import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
+import com.shypolarbear.domain.model.feed.feedLike.FeedLikeResponse
 import com.shypolarbear.domain.repository.feed.FeedRepo
 import javax.inject.Inject
 
@@ -119,6 +120,22 @@ class FeedRepoImpl @Inject constructor(
                     feedImages = listOf("NULL"),  // TODO("이미지 작업 완료되면 수정할 예정"
                 )
             )
+            when {
+                response.isSuccessful -> {
+                    Result.success(response.body()!!)
+                }
+                else -> {
+                    Result.failure(HttpError(response.code(), response.errorBody()?.string() ?: ""))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun requestLikeFeedData(feedId: Int): Result<FeedLikeResponse> {
+        return try {
+            val response = api.likeFeed(feedId)
             when {
                 response.isSuccessful -> {
                     Result.success(response.body()!!)

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
@@ -3,7 +3,7 @@ package com.shypolarbear.data.repositoryimpl.feed
 import com.shypolarbear.data.api.feed.FeedApi
 import com.shypolarbear.domain.model.HttpError
 import com.shypolarbear.domain.model.feed.FeedTotal
-import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedChange.WriteFeedForm
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
@@ -61,12 +61,12 @@ class FeedRepoImpl @Inject constructor(
         }
     }
 
-    override suspend fun requestChangePost(
+    override suspend fun requestChangePostData(
         feedId: Int,
         content: String,
         feedImages: List<String>?,
         title: String
-    ): Result<ChangePostResponse> {
+    ): Result<FeedChangeResponse> {
         return try {
             val response = api.requestChangePost(
                 feedId,
@@ -77,6 +77,22 @@ class FeedRepoImpl @Inject constructor(
                     title = title
                 )
             )
+            when {
+                response.isSuccessful -> {
+                    Result.success(response.body()!!)
+                }
+                else -> {
+                    Result.failure(HttpError(response.code(), response.errorBody()?.string() ?: ""))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteFeedData(feedId: Int): Result<FeedChangeResponse> {
+        return try {
+            val response = api.deleteFeed(feedId)
             when {
                 response.isSuccessful -> {
                     Result.success(response.body()!!)

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/feed/FeedRepoImpl.kt
@@ -105,4 +105,30 @@ class FeedRepoImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun writeFeedData(
+        title: String,
+        content: String,
+        feedImages: List<String>?
+    ): Result<FeedChangeResponse> {
+        return try {
+            val response = api.writeFeed(
+                WriteFeedForm(
+                    title = title,
+                    content = content,
+                    feedImages = listOf("NULL"),  // TODO("이미지 작업 완료되면 수정할 예정"
+                )
+            )
+            when {
+                response.isSuccessful -> {
+                    Result.success(response.body()!!)
+                }
+                else -> {
+                    Result.failure(HttpError(response.code(), response.errorBody()?.string() ?: ""))
+                }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/FeedChangeResponse.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/FeedChangeResponse.kt
@@ -1,6 +1,6 @@
 package com.shypolarbear.domain.model.feed.feedChange
 
-data class ChangePostResponse(
+data class FeedChangeResponse(
     val code: Int,
     val data : FeedId,
     val message: String

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/WriteFeedForm.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedChange/WriteFeedForm.kt
@@ -2,7 +2,7 @@ package com.shypolarbear.domain.model.feed.feedChange
 
 data class WriteFeedForm(
     val content: String,
-    val feedId: Int,
+    val feedId: Int = 0,
     val feedImages: List<String>?,
     val title: String
 )

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedLike/FeedLikeResponse.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedLike/FeedLikeResponse.kt
@@ -1,0 +1,7 @@
+package com.shypolarbear.domain.model.feed.feedLike
+
+data class FeedLikeResponse(
+    val code: Int,
+    val data: Result,
+    val message: String
+)

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/feedLike/Result.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/feedLike/Result.kt
@@ -1,0 +1,5 @@
+package com.shypolarbear.domain.model.feed.feedLike
+
+data class Result(
+    val result: String
+)

--- a/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
@@ -4,6 +4,7 @@ import com.shypolarbear.domain.model.feed.FeedTotal
 import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
+import com.shypolarbear.domain.model.feed.feedLike.FeedLikeResponse
 
 interface FeedRepo {
     suspend fun getFeedTotalData(): Result<FeedTotal>
@@ -26,4 +27,6 @@ interface FeedRepo {
         content: String,
         feedImages: List<String>?
     ): Result<FeedChangeResponse>
+
+    suspend fun requestLikeFeedData(feedId: Int): Result<FeedLikeResponse>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
@@ -1,7 +1,7 @@
 package com.shypolarbear.domain.repository.feed
 
 import com.shypolarbear.domain.model.feed.FeedTotal
-import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.model.feed.feedDetail.FeedComment
 import com.shypolarbear.domain.model.feed.feedDetail.FeedDetail
 
@@ -12,10 +12,12 @@ interface FeedRepo {
 
     suspend fun getFeedCommentData(feedId: Int): Result<FeedComment>
 
-    suspend fun requestChangePost(
+    suspend fun requestChangePostData(
         feedId: Int,
         content: String,
         feedImages: List<String>?,
         title: String
-    ): Result<ChangePostResponse>
+    ): Result<FeedChangeResponse>
+
+    suspend fun deleteFeedData(feedId: Int): Result<FeedChangeResponse>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/repository/feed/FeedRepo.kt
@@ -20,4 +20,10 @@ interface FeedRepo {
     ): Result<FeedChangeResponse>
 
     suspend fun deleteFeedData(feedId: Int): Result<FeedChangeResponse>
+
+    suspend fun writeFeedData(
+        title: String,
+        content: String,
+        feedImages: List<String>?
+    ): Result<FeedChangeResponse>
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/ChangePostUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/ChangePostUseCase.kt
@@ -1,6 +1,6 @@
 package com.shypolarbear.domain.usecase.feed
 
-import com.shypolarbear.domain.model.feed.feedChange.ChangePostResponse
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.repository.feed.FeedRepo
 
 class ChangePostUseCase (
@@ -11,7 +11,7 @@ class ChangePostUseCase (
         content: String,
         feedImages: List<String>?,
         title: String
-    ): Result<ChangePostResponse> {
-        return repo.requestChangePost(feedId, content, feedImages, title)
+    ): Result<FeedChangeResponse> {
+        return repo.requestChangePostData(feedId, content, feedImages, title)
     }
 }

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedChangeUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedChangeUseCase.kt
@@ -3,7 +3,7 @@ package com.shypolarbear.domain.usecase.feed
 import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
 import com.shypolarbear.domain.repository.feed.FeedRepo
 
-class ChangePostUseCase (
+class FeedChangeUseCase (
     private val repo: FeedRepo
 ) {
     suspend fun requestChangePost(

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedDeleteUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedDeleteUseCase.kt
@@ -1,0 +1,12 @@
+package com.shypolarbear.domain.usecase.feed
+
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
+import com.shypolarbear.domain.repository.feed.FeedRepo
+
+class FeedDeleteUseCase(
+    private val repo: FeedRepo
+) {
+    suspend fun requestDeleteFeed(feedId: Int): Result<FeedChangeResponse> {
+        return repo.deleteFeedData(feedId)
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedLikeUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedLikeUseCase.kt
@@ -1,0 +1,12 @@
+package com.shypolarbear.domain.usecase.feed
+
+import com.shypolarbear.domain.model.feed.feedLike.FeedLikeResponse
+import com.shypolarbear.domain.repository.feed.FeedRepo
+
+class FeedLikeUseCase (
+    private val repo: FeedRepo
+) {
+    suspend fun requestLikeFeed(feedId: Int): Result<FeedLikeResponse> {
+        return repo.requestLikeFeedData(feedId)
+    }
+}

--- a/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedWriteUseCase.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/usecase/feed/FeedWriteUseCase.kt
@@ -1,0 +1,17 @@
+package com.shypolarbear.domain.usecase.feed
+
+import com.shypolarbear.domain.model.feed.FeedTotal
+import com.shypolarbear.domain.model.feed.feedChange.FeedChangeResponse
+import com.shypolarbear.domain.repository.feed.FeedRepo
+
+class FeedWriteUseCase(
+    private val repo: FeedRepo
+) {
+    suspend fun requestWriteFeed(
+        title: String,
+        content: String,
+        feedImages: List<String>?
+    ): Result<FeedChangeResponse> {
+        return repo.writeFeedData(title, content, feedImages)
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedDetail/FeedDetailFragment.kt
@@ -64,7 +64,7 @@ class FeedDetailFragment : BaseFragment<FragmentFeedDetailBinding, FeedDetailVie
             progressFeedDetailLoading.isVisible = true
 
             btnFeedDetailBack.setOnClickListener {
-                findNavController().navigate(R.id.action_feedDetailFragment_to_feedTotalFragment)
+                findNavController().popBackStack()
             }
 
             edtFeedDetailReply.setOnFocusChangeListener { _, isFocus ->

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -132,9 +132,6 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                 getString(R.string.feed_post_property_delete) -> {
                     viewModel.requestDeleteFeed(feedId)
                     viewModel.removeFeedList(position)
-                    viewModel.feed.observe(viewLifecycleOwner) {
-                        feedPostAdapter.submitList(it.toList())
-                    }
                 }
             }
         }.showAsDropDown(

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -102,7 +102,7 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         binding.rvFeedPost.adapter = feedPostAdapter
         lifecycleScope.launch {
             viewModel.feed.observe(viewLifecycleOwner) {
-                feedPostAdapter.submitList(it)
+                feedPostAdapter.submitList(it.toList())
                 binding.progressFeedTotalLoading.isVisible = false
                 binding.layoutFeed.isVisible = true
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -7,16 +7,19 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentFeedTotalBinding
 import com.shypolarbear.presentation.ui.feed.feedTotal.adapter.FeedPostAdapter
 import com.shypolarbear.presentation.util.PowerMenuUtil
+import com.shypolarbear.presentation.util.infiniteScroll
 import com.shypolarbear.presentation.util.showLikeBtnIsLike
 import com.shypolarbear.presentation.util.setMenu
 import com.skydoves.powermenu.PowerMenuItem
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 enum class WriteChangeDivider(val fragmentType: Int) {
     WRITE(0),
@@ -73,6 +76,7 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
             binding.layoutFeed.isVisible = false
 
             viewModel.loadFeedTotalData()
+            setFeedPost()
 
             ivFeedToolbarSort.setOnClickListener {
                 ivFeedToolbarSort.setMenu(
@@ -89,7 +93,8 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                     )
                 )
             }
-            setFeedPost()
+
+            rvFeedPost.infiniteScroll { viewModel.loadFeedTotalData() }
         }
     }
 
@@ -125,8 +130,7 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                     )
                 }
                 getString(R.string.feed_post_property_delete) -> {
-                    // TODO("게시물 삭제 클릭 시 동작")
-//                    viewModel.requestDeleteFeed(feedId)
+                    viewModel.requestDeleteFeed(feedId)
                     viewModel.removeFeedList(position)
                     viewModel.feed.observe(viewLifecycleOwner) {
                         feedPostAdapter.submitList(it.toList())

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -35,8 +35,8 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
 
     override val viewModel: FeedTotalViewModel by viewModels()
     private val feedPostAdapter = FeedPostAdapter(
-        onMyPostPropertyClick = { view: ImageView, feedId: Int ->
-            showMyPostPropertyMenu(view, feedId)
+        onMyPostPropertyClick = { view: ImageView, feedId: Int, position: Int ->
+            showMyPostPropertyMenu(view, feedId, position)
         },
         onOtherPostPropertyClick = { view: ImageView ->
             showOtherPostPropertyMenu(view)
@@ -104,7 +104,7 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
         }
     }
 
-    private fun showMyPostPropertyMenu(view: ImageView, feedId: Int) {
+    private fun showMyPostPropertyMenu(view: ImageView, feedId: Int, position: Int) {
         val myCommentPropertyItems: List<PowerMenuItem> =
             listOf(
                 PowerMenuItem(requireContext().getString(R.string.feed_post_property_revise)),
@@ -126,7 +126,11 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                 }
                 getString(R.string.feed_post_property_delete) -> {
                     // TODO("게시물 삭제 클릭 시 동작")
-                    viewModel.requestDeleteFeed(feedId)
+//                    viewModel.requestDeleteFeed(feedId)
+                    viewModel.removeFeedList(position)
+                    viewModel.feed.observe(viewLifecycleOwner) {
+                        feedPostAdapter.submitList(it.toList())
+                    }
                 }
             }
         }.showAsDropDown(

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalFragment.kt
@@ -125,7 +125,8 @@ class FeedTotalFragment: BaseFragment<FragmentFeedTotalBinding, FeedTotalViewMod
                     )
                 }
                 getString(R.string.feed_post_property_delete) -> {
-                    // TODO("게시뭏 삭제 클릭 시 동작")
+                    // TODO("게시물 삭제 클릭 시 동작")
+                    viewModel.requestDeleteFeed(feedId)
                 }
             }
         }.showAsDropDown(

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -52,7 +52,6 @@ class FeedTotalViewModel @Inject constructor (
                                     feedList.add(Feed())            // progress bar
 
                                     _feed.value = feedList
-                                    Timber.d("피드 리스트 개수: ${feedList.size}")
                                 }
                                 .onFailure {
 
@@ -61,6 +60,7 @@ class FeedTotalViewModel @Inject constructor (
 
                     }
 
+//                    TODO("전체 피드 조회 api 구현 시 이거로 데이터 받아서 처리할 예정")
 //                    val newDataList = it.data.feeds
 //                    val currentList = _feed.value ?: emptyList()
 //                    _feed.value = currentList + newDataList

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -19,7 +19,7 @@ class FeedTotalViewModel @Inject constructor (
     private val feedTotalUseCase: FeedTotalUseCase,
     private val feedDeleteUseCase: FeedDeleteUseCase,
     private val feedLikeUseCase: FeedLikeUseCase,
-    private val feedDetailUseCase: FeedDetailUseCase
+    private val feedDetailUseCase: FeedDetailUseCase        // 테스트 용
 ): BaseViewModel() {
 
     private val _feed = MutableLiveData<List<Feed>>()
@@ -32,34 +32,38 @@ class FeedTotalViewModel @Inject constructor (
 
             feedData
                 .onSuccess {
-//                    when {
-//                        // 처음 로딩하는 경우
-//                        _feed.value.isNullOrEmpty() -> {
-//                            val feedList = mutableListOf<Feed>()
-//                            feedList.addAll(it.data.feeds)
-//
-//                            _feed.value = feedList
-//                        }
-//                        // 다음 페이지 로딩하는 경우
-//                        else -> {
-//                            feedDetailTestData
-//                                .onSuccess {
-//                                    val feedList = _feed.value as MutableList<Feed>
-//                                    feedList.addAll(listOf(it.data))
-//
-//                                    _feed.value = feedList
-//                                    Timber.d("피드 리스트 개수: ${feedList.size}")
-//                                }
-//                                .onFailure {
-//
-//                                }
-//                        }
-//
-//                    }
+                    when {
+                        // 처음 로딩하는 경우
+                        _feed.value.isNullOrEmpty() -> {
+                            val feedList = mutableListOf<Feed>()
+                            feedList.addAll(it.data.feeds)
+                            feedList.add(Feed())            // progress bar
 
-                    val newDataList = it.data.feeds
-                    val currentList = _feed.value ?: emptyList()
-                    _feed.value = currentList + newDataList
+                            _feed.value = feedList
+                        }
+                        // 다음 페이지 로딩하는 경우
+                        else -> {
+                            // 테스트 용
+                            feedDetailTestData
+                                .onSuccess { feedDetail ->
+                                    val feedList = _feed.value as MutableList<Feed>
+                                    feedList.removeLast()
+                                    feedList.addAll(listOf(feedDetail.data))
+                                    feedList.add(Feed())            // progress bar
+
+                                    _feed.value = feedList
+                                    Timber.d("피드 리스트 개수: ${feedList.size}")
+                                }
+                                .onFailure {
+
+                                }
+                        }
+
+                    }
+
+//                    val newDataList = it.data.feeds
+//                    val currentList = _feed.value ?: emptyList()
+//                    _feed.value = currentList + newDataList
                 }
                 .onFailure {
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
+import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.domain.usecase.feed.FeedLikeUseCase
 import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
@@ -17,7 +18,8 @@ import javax.inject.Inject
 class FeedTotalViewModel @Inject constructor (
     private val feedTotalUseCase: FeedTotalUseCase,
     private val feedDeleteUseCase: FeedDeleteUseCase,
-    private val feedLikeUseCase: FeedLikeUseCase
+    private val feedLikeUseCase: FeedLikeUseCase,
+    private val feedDetailUseCase: FeedDetailUseCase
 ): BaseViewModel() {
 
     private val _feed = MutableLiveData<List<Feed>>()
@@ -26,10 +28,38 @@ class FeedTotalViewModel @Inject constructor (
     fun loadFeedTotalData() {
         viewModelScope.launch {
             val feedData = feedTotalUseCase.loadFeedTotalData()
+            val feedDetailTestData = feedDetailUseCase.loadFeedDetailData(1)
 
             feedData
                 .onSuccess {
-                    _feed.value = it.data.feeds
+//                    when {
+//                        // 처음 로딩하는 경우
+//                        _feed.value.isNullOrEmpty() -> {
+//                            val feedList = mutableListOf<Feed>()
+//                            feedList.addAll(it.data.feeds)
+//
+//                            _feed.value = feedList
+//                        }
+//                        // 다음 페이지 로딩하는 경우
+//                        else -> {
+//                            feedDetailTestData
+//                                .onSuccess {
+//                                    val feedList = _feed.value as MutableList<Feed>
+//                                    feedList.addAll(listOf(it.data))
+//
+//                                    _feed.value = feedList
+//                                    Timber.d("피드 리스트 개수: ${feedList.size}")
+//                                }
+//                                .onFailure {
+//
+//                                }
+//                        }
+//
+//                    }
+
+                    val newDataList = it.data.feeds
+                    val currentList = _feed.value ?: emptyList()
+                    _feed.value = currentList + newDataList
                 }
                 .onFailure {
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -19,7 +19,7 @@ class FeedTotalViewModel @Inject constructor (
     private val feedTotalUseCase: FeedTotalUseCase,
     private val feedDeleteUseCase: FeedDeleteUseCase,
     private val feedLikeUseCase: FeedLikeUseCase,
-    private val feedDetailUseCase: FeedDetailUseCase        // 테스트 용
+    private val feedDetailUseCase: FeedDetailUseCase        // 테스트 용 TODO("전체 피드 조회 api 구현 시 제거")
 ): BaseViewModel() {
 
     private val _feed = MutableLiveData<List<Feed>>()
@@ -43,7 +43,7 @@ class FeedTotalViewModel @Inject constructor (
                         }
                         // 다음 페이지 로딩하는 경우
                         else -> {
-                            // 테스트 용
+                            // 테스트 용 TODO("전체 피드 조회 api 구현 시 수정")
                             feedDetailTestData
                                 .onSuccess { feedDetail ->
                                     val feedList = _feed.value as MutableList<Feed>

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
+import com.shypolarbear.domain.usecase.feed.FeedLikeUseCase
 import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class FeedTotalViewModel @Inject constructor (
     private val feedTotalUseCase: FeedTotalUseCase,
-    private val feedDeleteUseCase: FeedDeleteUseCase
+    private val feedDeleteUseCase: FeedDeleteUseCase,
+    private val feedLikeUseCase: FeedLikeUseCase
 ): BaseViewModel() {
 
     private val _feed = MutableLiveData<List<Feed>>()
@@ -32,7 +34,6 @@ class FeedTotalViewModel @Inject constructor (
                 .onFailure {
 
                 }
-
         }
     }
 
@@ -50,6 +51,9 @@ class FeedTotalViewModel @Inject constructor (
                 feed.copy(isLike = isLiked, likeCount = likeCnt)
             else
                 feed
+        }
+        viewModelScope.launch {
+            feedLikeUseCase.requestLikeFeed(feedId)
         }
         _feed.value = updatedFeed
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
+import com.shypolarbear.domain.usecase.feed.FeedDeleteUseCase
 import com.shypolarbear.domain.usecase.feed.FeedTotalUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +14,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FeedTotalViewModel @Inject constructor (
-    private val feedTotalUseCase: FeedTotalUseCase
+    private val feedTotalUseCase: FeedTotalUseCase,
+    private val feedDeleteUseCase: FeedDeleteUseCase
 ): BaseViewModel() {
 
     private val _feed = MutableLiveData<List<Feed>>()
@@ -31,6 +33,12 @@ class FeedTotalViewModel @Inject constructor (
 
                 }
 
+        }
+    }
+
+    fun requestDeleteFeed(feedId: Int) {
+        viewModelScope.launch {
+            feedDeleteUseCase.requestDeleteFeed(feedId)
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/FeedTotalViewModel.kt
@@ -67,4 +67,13 @@ class FeedTotalViewModel @Inject constructor (
         }
         _feed.value = updatedFeed
     }
+
+    fun removeFeedList(position: Int) {
+        val feedList: MutableList<Feed> = mutableListOf()
+
+        feedList.addAll(0, _feed.value!!)
+
+        feedList.removeAt(position)
+        _feed.value = feedList
+    }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
@@ -7,10 +7,23 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.shypolarbear.domain.model.feed.Comment
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.presentation.databinding.ItemFeedBinding
+import com.shypolarbear.presentation.databinding.ItemFeedLoadingBinding
+import com.shypolarbear.presentation.ui.feed.feedDetail.FeedCommentViewType
+import com.shypolarbear.presentation.ui.feed.feedDetail.viewholder.FeedCommentDeleteViewHolder
+import com.shypolarbear.presentation.ui.feed.feedDetail.viewholder.FeedCommentNormalViewHolder
 import com.shypolarbear.presentation.ui.feed.feedTotal.FeedTotalLikeBtnType
+import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedLoadingViewHolder
 import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedPostViewHolder
+import timber.log.Timber
+
+enum class FeedViewType(val viewType: Int) {
+    LOADING(0),
+    ITEM(1)
+}
 
 class FeedPostAdapter(
     private val onMyPostPropertyClick: (view: ImageView, feedId: Int, position: Int) -> Unit = { _, _, _ -> },
@@ -26,25 +39,53 @@ class FeedPostAdapter(
         itemType: FeedTotalLikeBtnType
             ) -> Unit = { _, _, _, _, _, _ -> },
     private val onMoveToDetailClick: (feedId: Int) -> Unit = { }
-    ): ListAdapter<Feed, FeedPostViewHolder>(FeedPostDiffCallback()) {
+    ): ListAdapter<Feed, RecyclerView.ViewHolder>(FeedPostDiffCallback()) {
 
-    private lateinit var binding : ItemFeedBinding
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedPostViewHolder {
-        binding = ItemFeedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return FeedPostViewHolder(
-            binding,
-            onMyPostPropertyClick = onMyPostPropertyClick,
-            onOtherPostPropertyClick = onOtherPostPropertyClick,
-            onMyBestCommentPropertyClick = onMyBestCommentPropertyClick,
-            onOtherBestCommentPropertyClick = onOtherBestCommentPropertyClick,
-            onBtnLikeClick = onBtnLikeClick,
-            onMoveToDetailClick = onMoveToDetailClick
-        )
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        when(viewType) {
+            FeedViewType.LOADING.viewType -> {
+                return FeedLoadingViewHolder(
+                    ItemFeedLoadingBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                )
+            }
+            FeedViewType.ITEM.viewType -> {
+                return FeedPostViewHolder(
+                    ItemFeedBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+                    onMyPostPropertyClick = onMyPostPropertyClick,
+                    onOtherPostPropertyClick = onOtherPostPropertyClick,
+                    onMyBestCommentPropertyClick = onMyBestCommentPropertyClick,
+                    onOtherBestCommentPropertyClick = onOtherBestCommentPropertyClick,
+                    onBtnLikeClick = onBtnLikeClick,
+                    onMoveToDetailClick = onMoveToDetailClick
+                )
+            }
+            else -> {
+                throw Exception()
+            }
+        }
     }
 
-    override fun onBindViewHolder(holder: FeedPostViewHolder, position: Int) {
-        holder.bind(getItem(position))
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when(getItem(position).feedId) {
+            0 -> {
+                (holder as FeedLoadingViewHolder).bind(getItem(position))
+            }
+            else -> {
+                (holder as FeedPostViewHolder).bind(getItem(position))
+            }
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        Timber.d("feedId: ${getItem(position).feedId}")
+        return when(getItem(position).feedId) {
+            0 -> {
+                FeedViewType.LOADING.viewType
+            }
+            else -> {
+                FeedViewType.ITEM.viewType
+            }
+        }
     }
 }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
@@ -13,7 +13,7 @@ import com.shypolarbear.presentation.ui.feed.feedTotal.FeedTotalLikeBtnType
 import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedPostViewHolder
 
 class FeedPostAdapter(
-    private val onMyPostPropertyClick: (view: ImageView, feedId: Int) -> Unit = { _, _ -> },
+    private val onMyPostPropertyClick: (view: ImageView, feedId: Int, position: Int) -> Unit = { _, _, _ -> },
     private val onOtherPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onMyBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onOtherBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
@@ -8,17 +8,12 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.shypolarbear.domain.model.feed.Comment
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.presentation.databinding.ItemFeedBinding
 import com.shypolarbear.presentation.databinding.ItemFeedLoadingBinding
-import com.shypolarbear.presentation.ui.feed.feedDetail.FeedCommentViewType
-import com.shypolarbear.presentation.ui.feed.feedDetail.viewholder.FeedCommentDeleteViewHolder
-import com.shypolarbear.presentation.ui.feed.feedDetail.viewholder.FeedCommentNormalViewHolder
 import com.shypolarbear.presentation.ui.feed.feedTotal.FeedTotalLikeBtnType
 import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedLoadingViewHolder
 import com.shypolarbear.presentation.ui.feed.feedTotal.viewholder.FeedPostViewHolder
-import timber.log.Timber
 
 enum class FeedViewType(val viewType: Int) {
     LOADING(0),
@@ -77,7 +72,6 @@ class FeedPostAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        Timber.d("feedId: ${getItem(position).feedId}")
         return when(getItem(position).feedId) {
             0 -> {
                 FeedViewType.LOADING.viewType

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedLoadingViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedLoadingViewHolder.kt
@@ -1,0 +1,12 @@
+package com.shypolarbear.presentation.ui.feed.feedTotal.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.shypolarbear.domain.model.feed.Feed
+import com.shypolarbear.presentation.databinding.ItemFeedLoadingBinding
+
+class FeedLoadingViewHolder(private val binding: ItemFeedLoadingBinding) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(item: Feed) {
+
+        binding.executePendingBindings()
+    }
+}

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
@@ -18,7 +18,7 @@ import timber.log.Timber
 
 class FeedPostViewHolder(
     private val binding: ItemFeedBinding,
-    private val onMyPostPropertyClick: (view: ImageView, feedId: Int) -> Unit = { _, _ -> },
+    private val onMyPostPropertyClick: (view: ImageView, feedId: Int, position: Int) -> Unit = { _, _, _ -> },
     private val onOtherPostPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onMyBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
     private val onOtherBestCommentPropertyClick: (view: ImageView) -> Unit = { _ -> },
@@ -44,7 +44,7 @@ class FeedPostViewHolder(
         // 게시물 작성자 확인
         binding.ivFeedPostProperty.setOnClickListener {
             when(post.isAuthor) {
-                true -> onMyPostPropertyClick(binding.ivFeedPostProperty, post.feedId)
+                true -> onMyPostPropertyClick(binding.ivFeedPostProperty, post.feedId, adapterPosition)
                 false -> onOtherPostPropertyClick(binding.ivFeedPostProperty)
             }
         }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -71,7 +71,8 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
             }
 
             btnFeedWriteBack.setOnClickListener {
-                findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+                findNavController().popBackStack()
+
             }
 
             btnFeedWriteAddPhoto.setOnClickListener {
@@ -105,7 +106,7 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                                 )
                             }
                         }
-                        findNavController().navigate(R.id.action_feedWriteFragment_to_navigation_feed)
+                        findNavController().popBackStack()
                     }
                 }
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -89,7 +89,12 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                     else -> {
                         when(feedWriteArgs.divider) {
                             WriteChangeDivider.WRITE -> {
-
+                                // TODO("피드 작성 시 동작")
+                                viewModel.writePost(
+                                    title = edtFeedWriteTitle.text.toString(),
+                                    content = edtFeedWriteContent.text.toString(),
+                                    feedImages = null
+                                )
                             }
                             WriteChangeDivider.CHANGE -> {
                                 viewModel.changePost(

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -8,6 +8,7 @@ import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
+import com.shypolarbear.domain.usecase.feed.FeedWriteUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -17,7 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
     private val feedDetailUseCase: FeedDetailUseCase,
-    private val changePostUseCase: ChangePostUseCase
+    private val changePostUseCase: ChangePostUseCase,
+    private val feedWriteUseCase: FeedWriteUseCase
 ): BaseViewModel(){
     private val _feed = MutableLiveData<Feed>()
     val feed: LiveData<Feed> = _feed
@@ -42,6 +44,12 @@ class FeedWriteViewModel @Inject constructor(
     fun changePost(feedId: Int, content: String, feedImages: List<String>?, title: String) {
         viewModelScope.launch {
             changePostUseCase.requestChangePost(feedId, content, feedImages, title)
+        }
+    }
+
+    fun writePost(title: String, content: String, feedImages: List<String>?) {
+        viewModelScope.launch {
+            feedWriteUseCase.requestWriteFeed(title, content, feedImages)
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -6,19 +6,18 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
-import com.shypolarbear.domain.usecase.feed.ChangePostUseCase
+import com.shypolarbear.domain.usecase.feed.FeedChangeUseCase
 import com.shypolarbear.domain.usecase.feed.FeedDetailUseCase
 import com.shypolarbear.domain.usecase.feed.FeedWriteUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
     private val feedDetailUseCase: FeedDetailUseCase,
-    private val changePostUseCase: ChangePostUseCase,
+    private val changePostUseCase: FeedChangeUseCase,
     private val feedWriteUseCase: FeedWriteUseCase
 ): BaseViewModel(){
     private val _feed = MutableLiveData<Feed>()

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -43,7 +43,7 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
             }
 
             btnChangeMyInfoBack.setOnClickListener {
-                findNavController().navigate(R.id.action_changeMyInfoFragment_to_navigation_more)
+                findNavController().popBackStack()
             }
 
             btnChangeMyInfoRevise.setOnClickListener {
@@ -68,7 +68,7 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                             profileImage = null
                         )
                         Toast.makeText(requireContext(), getString(R.string.check_my_info_success), Toast.LENGTH_SHORT).show()
-                        findNavController().navigate(R.id.action_changeMyInfoFragment_to_navigation_more)
+                        findNavController().popBackStack()
                     }
                 }
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
@@ -25,11 +25,13 @@ import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.findNavController
+import androidx.recyclerview.widget.RecyclerView
 import com.shypolarbear.domain.model.Tokens
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.ui.feed.feedTotal.FeedTotalFragment
 import com.shypolarbear.presentation.ui.quiz.daily.dialog.QuizDialog
 import com.skydoves.powermenu.PowerMenuItem
+import timber.log.Timber
 
 
 val emailPattern = Regex("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}")
@@ -256,4 +258,18 @@ fun Fragment.hideKeyboard() {
             InputMethodManager.HIDE_NOT_ALWAYS
         )
     }
+}
+
+fun RecyclerView.infiniteScroll(method: () -> Unit) {
+    addOnScrollListener(object : RecyclerView.OnScrollListener() {
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            super.onScrolled(recyclerView, dx, dy)
+
+            when {
+                !canScrollVertically(1) -> {
+                    method()
+                }
+            }
+        }
+    })
 }

--- a/presentation/src/main/res/layout/fragment_feed_detail.xml
+++ b/presentation/src/main/res/layout/fragment_feed_detail.xml
@@ -15,7 +15,6 @@
             android:id="@+id/progress_feed_detail_loading"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
             android:indeterminate="true"
             app:indicatorColor="@color/Blue_02"
             app:indicatorSize="36dp"

--- a/presentation/src/main/res/layout/fragment_feed_total.xml
+++ b/presentation/src/main/res/layout/fragment_feed_total.xml
@@ -81,20 +81,14 @@
 
             </com.google.android.material.appbar.AppBarLayout>
 
-            <androidx.core.widget.NestedScrollView
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_feed_post"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginTop="60dp"
                 android:layout_marginBottom="60dp"
-                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rv_feed_post"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    tools:listitem="@layout/item_feed" />
-
-            </androidx.core.widget.NestedScrollView>
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_feed" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_feed_post_write"

--- a/presentation/src/main/res/layout/fragment_feed_total.xml
+++ b/presentation/src/main/res/layout/fragment_feed_total.xml
@@ -15,7 +15,6 @@
             android:id="@+id/progress_feed_total_loading"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
             android:indeterminate="true"
             app:indicatorColor="@color/Blue_02"
             app:indicatorSize="36dp"

--- a/presentation/src/main/res/layout/item_feed_loading.xml
+++ b/presentation/src/main/res/layout/item_feed_loading.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_feed_total_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:indeterminate="true"
+            app:indicatorColor="@color/Blue_02"
+            app:indicatorSize="24dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:trackThickness="3dp" />
+
+        <View
+            android:id="@+id/view_feed_post_div"
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:background="@color/Blue_06"
+            app:layout_constraintTop_toBottomOf="@+id/progress_feed_total_loading" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_feed_loading.xml
+++ b/presentation/src/main/res/layout/item_feed_loading.xml
@@ -17,18 +17,18 @@
             android:layout_margin="8dp"
             android:indeterminate="true"
             app:indicatorColor="@color/Blue_02"
-            app:indicatorSize="24dp"
+            app:indicatorSize="36dp"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:trackThickness="3dp" />
 
         <View
-            android:id="@+id/view_feed_post_div"
+            android:id="@+id/view_feed_loading_div"
             android:layout_width="match_parent"
             android:layout_height="4dp"
             android:background="@color/Blue_06"
+            android:layout_marginTop="36dp"
             app:layout_constraintTop_toBottomOf="@+id/progress_feed_total_loading" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_feed_loading.xml
+++ b/presentation/src/main/res/layout/item_feed_loading.xml
@@ -23,13 +23,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:trackThickness="3dp" />
 
-        <View
-            android:id="@+id/view_feed_loading_div"
-            android:layout_width="match_parent"
-            android:layout_height="4dp"
-            android:background="@color/Blue_06"
-            android:layout_marginTop="36dp"
-            app:layout_constraintTop_toBottomOf="@+id/progress_feed_total_loading" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -22,9 +22,6 @@
         android:name="com.shypolarbear.presentation.ui.feed.feedDetail.FeedDetailFragment"
         android:label="FeedDetailFragment"
         tools:layout="@layout/fragment_feed_detail">
-        <action
-            android:id="@+id/action_feedDetailFragment_to_feedTotalFragment"
-            app:destination="@id/navigation_feed" />
         <argument
             android:name="feedId"
             app:argType="integer" />
@@ -34,9 +31,6 @@
         android:name="com.shypolarbear.presentation.ui.feed.feedWrite.FeedWriteFragment"
         android:label="FeedWriteFragment"
         tools:layout="@layout/fragment_feed_write">
-        <action
-            android:id="@+id/action_feedWriteFragment_to_navigation_feed"
-            app:destination="@id/navigation_feed" />
         <argument
             android:name="divider"
             app:argType="com.shypolarbear.presentation.ui.feed.feedTotal.WriteChangeDivider" />
@@ -118,9 +112,6 @@
         android:name="com.shypolarbear.presentation.ui.more.changemyinfo.ChangeMyInfoFragment"
         android:label="ChangeMyInfoFragment"
         tools:layout="@layout/fragment_change_my_info">
-        <action
-            android:id="@+id/action_changeMyInfoFragment_to_navigation_more"
-            app:destination="@id/navigation_more" />
     </fragment>
     <fragment
         android:id="@+id/loginFragment"

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/loginFragment">
+    app:startDestination="@id/navigation_feed">
 
     <fragment
         android:id="@+id/navigation_feed"

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.ShyPolarBear" parent="Theme.MaterialComponents.Light.NoActionBar" />
+    <style name="Theme.ShyPolarBear" parent="Theme.MaterialComponents.Light.NoActionBar" >
+        <item name="android:statusBarColor">@color/White_01</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
 
     <style name="Theme.SplashScreen.ShyPolarBear" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/white</item>


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 피드 좋아요, 작성, 삭제 api 적용
- 전체 피드 조회에 무한 스크롤 적용

🌱 PR 포인트
- 피드 좋아요, 작성, 삭제 api 적용하였는데 테스트는 해보지 못했습니다. 추후에 전체 피드 조회 api 구현 되면 그때 테스트 해볼 예정입니다.
- 무한 스크롤을 구현하였습니다. 무한 스크롤은 내가 작성한 피드, 댓글 보는 곳에서도 사용되기 때문에 확장 함수로 구현하였습니다. **feedTotalViewModel에서 받아온 피드 데이터를 관리하는 부분은 추후에 전체 피드 조회 api 구현 되면 그때 테스트하면서 수정할 예정입니다.**
- 상태 바의 색상은 투명으로 변경하였고, 뒤로 이동하는 동작을 nav_graph 에서 정의한 동작으로 수행하던 방식에서 popBackStack() 방식으로 변경하여 Fragment stack 관리를 하게 하였습니다.

## 📸 스크린샷
|스크린샷|
https://github.com/ShyPolarBear/Android/assets/107917980/f0e5275c-a51b-4531-92a5-e68d946abf4d
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #61 
