### PR TITLE
[WBS-221]Feature/apply image api

### DIFF
--- a/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/AuthNetworkModule.kt
@@ -10,6 +10,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -24,6 +25,9 @@ object AuthNetworkModule {
         authInterceptor: AuthInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .readTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
             .addInterceptor(logger)
             .addInterceptor(authInterceptor)
             .build()

--- a/app/src/main/java/com/shypolarbear/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/shypolarbear/android/di/NetworkModule.kt
@@ -16,6 +16,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -28,6 +29,9 @@ object NetworkModule {
         logger: HttpLoggingInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .readTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
             .addInterceptor(logger)
             .build()
     }

--- a/data/src/main/java/com/shypolarbear/data/repositoryimpl/InfoRepoImpl.kt
+++ b/data/src/main/java/com/shypolarbear/data/repositoryimpl/InfoRepoImpl.kt
@@ -35,7 +35,7 @@ class InfoRepoImpl @Inject constructor(
         return try {
             val response = api.changeMyInfo(ChangeInfoRequest(
                 nickName = nickName,
-                profileImage = "NULL",  // TODO("이미지 작업 완료되면 수정할 예정")
+                profileImage = profileImage,
                 email = email,
                 phoneNumber = phoneNumber)
             )

--- a/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/feed/FeedWriteImg.kt
@@ -1,5 +1,0 @@
-package com.shypolarbear.domain.model.feed
-
-data class FeedWriteImg(
-    val imgUrl: String
-)

--- a/domain/src/main/java/com/shypolarbear/domain/model/image/ImageData.kt
+++ b/domain/src/main/java/com/shypolarbear/domain/model/image/ImageData.kt
@@ -3,7 +3,7 @@ package com.shypolarbear.domain.model.image
 import java.io.File
 
 data class ImageUrls(
-    val imageUrls: List<String>,
+    val imageLinks: List<String>,
 )
 
 data class ImageFiles(

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/adapter/FeedPostAdapter.kt
@@ -90,7 +90,6 @@ class FeedPostAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        Timber.d("${getItem(position).feedImages.isNullOrEmpty() }")
         return when {
             getItem(position).feedId == 0 -> {
                 FeedViewType.LOADING.viewType

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedTotal/viewholder/FeedPostViewHolder.kt
@@ -5,6 +5,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.tabs.TabLayoutMediator
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.presentation.R
@@ -136,5 +137,6 @@ class FeedPostViewHolder(
 
             }.attach()
         }
+        binding.viewpagerFeedPostImg.setPageTransformer(MarginPageTransformer(100))
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -98,40 +98,41 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                         Toast.makeText(requireContext(), getString(R.string.feed_write_content_msg), Toast.LENGTH_SHORT).show()
                     }
                     else -> {
-                        when(feedWriteArgs.divider) {
-                            WriteChangeDivider.WRITE -> {
-                                // TODO("이미지 api 구현 되면 feedImages에 viewModel의 _liveImgList.value 넣기)
-
-//                                viewModel.requestUploadImages(ImageType.PROFILE.type, listOf(File(uri.convertUriToPath(requireContext()))))
-
-                                val imageFileList: List<File> = imageUriList.map { it ->
-                                    Timber.d("$it")
-                                    it.convertUriToFile(requireContext())
-                                }
-                                viewModel.requestUploadImages(ImageType.PROFILE.type, imageFileList)
-
-                                viewModel.uploadImageList.observe(viewLifecycleOwner) {
-                                    viewModel.writePost(
-                                        title = edtFeedWriteTitle.text.toString(),
-                                        content = edtFeedWriteContent.text.toString(),
-                                        feedImages = viewModel.uploadImageList.value
-                                    )
-                                }
-                            }
-                            WriteChangeDivider.CHANGE -> {
-                                viewModel.changePost(
-                                    feedId = feedWriteArgs.feedId,
-                                    content = edtFeedWriteContent.text.toString(),
-                                    feedImages = viewModel.uploadImageList.value,
-                                    title = edtFeedWriteTitle.text.toString()
-                                )
-                            }
-                        }
-                        fragmentTotalStatus = FragmentTotalStatus.POST_CHANGE_OR_DETAIL_BACK
-                        findNavController().popBackStack()
+                        uploadPost()
                     }
                 }
             }
+        }
+    }
+
+    private fun uploadPost() {
+        val imageFileList: List<File> = imageUriList.map { it ->
+            it.convertUriToFile(requireContext())
+        }
+
+        viewModel.requestUploadImages(ImageType.FEED.type, imageFileList)       // 이미지 업로드
+
+        viewModel.uploadImageList.observe(viewLifecycleOwner) {     // 이미지 업로드 되면 실행
+            when(feedWriteArgs.divider) {
+                WriteChangeDivider.WRITE -> {
+                    viewModel.writePost(
+                        title = binding.edtFeedWriteTitle.text.toString(),
+                        content = binding.edtFeedWriteContent.text.toString(),
+                        feedImages = viewModel.uploadImageList.value
+                    )
+                }
+                WriteChangeDivider.CHANGE -> {
+                    viewModel.changePost(
+                        feedId = feedWriteArgs.feedId,
+                        content = binding.edtFeedWriteContent.text.toString(),
+                        feedImages = viewModel.uploadImageList.value,
+                        title = binding.edtFeedWriteTitle.text.toString()
+                    )
+                }
+            }
+
+            fragmentTotalStatus = FragmentTotalStatus.POST_CHANGE_OR_DETAIL_BACK
+            findNavController().popBackStack()
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -46,7 +46,6 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                         Toast.makeText(requireContext(), getString(R.string.feed_write_image_count_msg), Toast.LENGTH_SHORT).show()
                     }
                     else -> {
-//                        imageUriList.addAll(0, uris)
                         addedImageUriList.addAll(0, uris)
                         viewModel.addImgList(uris)
                         binding.rvFeedWriteUploadImg.scrollToPosition(IMAGE_ADD_INDEX)

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteFragment.kt
@@ -145,7 +145,7 @@ class FeedWriteFragment: BaseFragment<FragmentFeedWriteBinding, FeedWriteViewMod
                         )
                     }
                     // 이미지 추가만 된 경우
-                    (originalImageUriList.size < imageUriList.size) -> {
+                    (originalImageUriList.size < (imageUriList.size + addedImageUriList.size)) -> {
                         val imageFileList: List<File> = addedImageUriList.map { it.convertUriToFile(requireContext()) }
                         viewModel.changeImagePost(
                             feedId = feedWriteArgs.feedId,

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgAdapter.kt
@@ -2,16 +2,13 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
-import timber.log.Timber
 
 class FeedWriteImgAdapter(
     private val onRemoveImgClick: (position: Int) -> Unit = { _ -> }
-): ListAdapter<FeedWriteImg, FeedWriteImgViewHolder>(FeedWriteImgDiffCallback()) {
+): ListAdapter<String, FeedWriteImgViewHolder>(FeedWriteImgDiffCallback()) {
 
     private lateinit var binding : ItemFeedWriteImgBinding
 
@@ -28,13 +25,13 @@ class FeedWriteImgAdapter(
     }
 }
 
-class FeedWriteImgDiffCallback : DiffUtil.ItemCallback<FeedWriteImg>() {
+class FeedWriteImgDiffCallback : DiffUtil.ItemCallback<String>() {
 
-    override fun areItemsTheSame(oldItem: FeedWriteImg, newItem: FeedWriteImg): Boolean {
-        return oldItem.imgUrl == newItem.imgUrl
+    override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
     }
 
-    override fun areContentsTheSame(oldItem: FeedWriteImg, newItem: FeedWriteImg): Boolean {
+    override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
         return oldItem == newItem
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteImgViewHolder.kt
@@ -2,11 +2,8 @@ package com.shypolarbear.presentation.ui.feed.feedWrite
 
 import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
-import com.shypolarbear.domain.model.feed.FeedWriteImg
-import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.databinding.ItemFeedWriteImgBinding
 import com.shypolarbear.presentation.util.GlideUtil
-import timber.log.Timber
 
 class FeedWriteImgViewHolder(
     private val binding: ItemFeedWriteImgBinding,
@@ -20,9 +17,9 @@ class FeedWriteImgViewHolder(
         }
     }
 
-    fun bind(item: FeedWriteImg) {
+    fun bind(item: String) {
         binding.apply {
-            GlideUtil.loadImage(itemView.context, item.imgUrl.toUri(), binding.ivFeedWriteImg)
+            GlideUtil.loadImage(itemView.context, item.toUri(), binding.ivFeedWriteImg)
             executePendingBindings()
         }
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -7,16 +7,13 @@ import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
 import com.shypolarbear.domain.model.image.ImageUploadRequest
-import com.shypolarbear.domain.model.image.ImageUploadResponse
 import com.shypolarbear.domain.usecase.feed.RequestFeedChangeUseCase
 import com.shypolarbear.domain.usecase.feed.LoadFeedDetailUseCase
 import com.shypolarbear.domain.usecase.feed.RequestFeedWriteUseCase
 import com.shypolarbear.domain.usecase.image.RequestImageUploadUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
-import com.shypolarbear.presentation.util.ImageType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -30,8 +27,8 @@ class FeedWriteViewModel @Inject constructor(
     private val _feed = MutableLiveData<Feed>()
     val feed: LiveData<Feed> = _feed
 
-    private val _liveImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
-    val liveImgList: LiveData<MutableList<FeedWriteImg>> = _liveImgList
+    private val _selectedLiveImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
+    val selectedLiveImgList: LiveData<MutableList<FeedWriteImg>> = _selectedLiveImgList
 
     private val _uploadImageList = MutableLiveData<List<String>>()
     val uploadImageList: LiveData<List<String>> = _uploadImageList
@@ -69,7 +66,6 @@ class FeedWriteViewModel @Inject constructor(
             uploadImages
                 .onSuccess {
                     _uploadImageList.value = it.data.imageLinks
-                    Timber.d("${_uploadImageList.value}")
                 }
                 .onFailure {
 
@@ -78,17 +74,25 @@ class FeedWriteViewModel @Inject constructor(
     }
 
     fun addImgList(imgUri: List<Uri>) {
-        val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!
-        val feedWriteImgList = imgUri.map { FeedWriteImg(it.toString()) }
+        val selectedImgList: MutableList<FeedWriteImg> = _selectedLiveImgList.value!!
+        val imgUriToStringList = imgUri.map { FeedWriteImg(it.toString()) }
 
-        imgList.addAll(0, feedWriteImgList)
-        _liveImgList.value = imgList
+        selectedImgList.addAll(0, imgUriToStringList)
+        _selectedLiveImgList.value = selectedImgList
     }
 
     fun removeImgList(position: Int) {
-        val imgList: MutableList<FeedWriteImg> = _liveImgList.value!!
+        val selectedImgList: MutableList<FeedWriteImg> = _selectedLiveImgList.value!!
+        val imgUploadList: MutableList<String> = _uploadImageList.value!!.toMutableList()
 
-        imgList.removeAt(position)
-        _liveImgList.value = imgList
+        imgUploadList.removeAt(position)
+        selectedImgList.removeAt(position)
+
+        _uploadImageList.value = imgUploadList
+        _selectedLiveImgList.value = selectedImgList
+    }
+
+    fun setUploadImageList(images: List<String>) {
+        _uploadImageList.value = images
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -68,7 +68,7 @@ class FeedWriteViewModel @Inject constructor(
 
             uploadImages
                 .onSuccess {
-                    _uploadImageList.value = it.data.imageUrls
+                    _uploadImageList.value = it.data.imageLinks
                     Timber.d("${_uploadImageList.value}")
                 }
                 .onFailure {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/feed/feedWrite/FeedWriteViewModel.kt
@@ -6,25 +6,35 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.shypolarbear.domain.model.feed.Feed
 import com.shypolarbear.domain.model.feed.FeedWriteImg
+import com.shypolarbear.domain.model.image.ImageUploadRequest
+import com.shypolarbear.domain.model.image.ImageUploadResponse
 import com.shypolarbear.domain.usecase.feed.RequestFeedChangeUseCase
 import com.shypolarbear.domain.usecase.feed.LoadFeedDetailUseCase
 import com.shypolarbear.domain.usecase.feed.RequestFeedWriteUseCase
+import com.shypolarbear.domain.usecase.image.RequestImageUploadUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
+import com.shypolarbear.presentation.util.ImageType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
 class FeedWriteViewModel @Inject constructor(
     private val feedDetailUseCase: LoadFeedDetailUseCase,
     private val changePostUseCase: RequestFeedChangeUseCase,
-    private val feedWriteUseCase: RequestFeedWriteUseCase
+    private val feedWriteUseCase: RequestFeedWriteUseCase,
+    private val imageUploadUseCase: RequestImageUploadUseCase
 ): BaseViewModel(){
     private val _feed = MutableLiveData<Feed>()
     val feed: LiveData<Feed> = _feed
 
     private val _liveImgList = MutableLiveData<MutableList<FeedWriteImg>>(mutableListOf())
     val liveImgList: LiveData<MutableList<FeedWriteImg>> = _liveImgList
+
+    private val _uploadImageList = MutableLiveData<List<String>>()
+    val uploadImageList: LiveData<List<String>> = _uploadImageList
 
     fun loadFeedDetail(feedId: Int) {
         viewModelScope.launch {
@@ -49,6 +59,21 @@ class FeedWriteViewModel @Inject constructor(
     fun writePost(title: String, content: String, feedImages: List<String>?) {
         viewModelScope.launch {
             feedWriteUseCase(title, content, feedImages)
+        }
+    }
+
+    fun requestUploadImages(imageType: String, imageFiles: List<File>) {
+        viewModelScope.launch {
+            val uploadImages = imageUploadUseCase(ImageUploadRequest(imageType, imageFiles))
+
+            uploadImages
+                .onSuccess {
+                    _uploadImageList.value = it.data.imageUrls
+                    Timber.d("${_uploadImageList.value}")
+                }
+                .onFailure {
+
+                }
         }
     }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreFragment.kt
@@ -5,6 +5,7 @@ import androidx.navigation.fragment.findNavController
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentMoreBinding
+import com.shypolarbear.presentation.util.GlideUtil
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -17,6 +18,15 @@ class MoreFragment: BaseFragment<FragmentMoreBinding, MoreViewModel> (
     override fun initView() {
 
         binding.apply {
+            viewModel.getMyInfo()
+            viewModel.myInfo.observe(viewLifecycleOwner) { info ->
+                tvMoreUserNickname.setText(info.nickName)
+                if (!info.profileImage.isNullOrBlank()) {
+                    GlideUtil.loadImage(requireContext(), info.profileImage, binding.ivMoreUserProfile)
+                } else {
+                    GlideUtil.loadImage(requireContext(), url = null, view = binding.ivMoreUserProfile, placeHolder = R.drawable.ic_user_base_profile)
+                }
+            }
 
             layoutMoreMyInfoChange.setOnClickListener {
                 findNavController().navigate(R.id.action_navigation_more_to_changeMyInfoFragment)

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/MoreViewModel.kt
@@ -1,12 +1,34 @@
 package com.shypolarbear.presentation.ui.more
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.shypolarbear.domain.model.more.Info
+import com.shypolarbear.domain.usecase.more.LoadMyInfoUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MoreViewModel @Inject constructor(
-
+    private val getMyInfoUseCase: LoadMyInfoUseCase
 ): BaseViewModel() {
+    private val _myInfo = MutableLiveData<Info>()
+    val myInfo: LiveData<Info> = _myInfo
 
+    fun getMyInfo() {
+        viewModelScope.launch {
+            val info = getMyInfoUseCase()
+
+            info
+                .onSuccess {
+                    _myInfo.value = it.data
+                }
+                .onFailure {
+
+                }
+
+        }
+    }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -66,9 +66,9 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                 profileImageUri = info.profileImage.toUri()
 
                 if (!info.profileImage.isNullOrBlank()) {
-                    GlideUtil.loadImage(requireContext(), info.profileImage, binding.ivChangeMyInfoProfile)
+                    GlideUtil.loadCircleImage(requireContext(), info.profileImage.toUri(), binding.ivChangeMyInfoProfile)
                 } else {
-                    GlideUtil.loadImage(requireContext(), url = null, view = binding.ivChangeMyInfoProfile, placeHolder = R.drawable.ic_user_base_profile)
+                    GlideUtil.loadCircleImage(requireContext(), url = null, view = binding.ivChangeMyInfoProfile, placeHolder = R.drawable.ic_user_base_profile)
                 }
 
                 progressChangeMyInfoLoading.isVisible = false

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -44,8 +44,10 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
 
     private val pickMedia =
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
-            uri?.let { profileImageUri = uri }
-
+            uri?.let {
+                profileImageUri = uri
+                GlideUtil.loadCircleImage(requireContext(), uri, binding.ivChangeMyInfoProfile)
+            }
         }
 
     override fun initView() {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -20,6 +20,7 @@ import com.shypolarbear.presentation.ui.feed.feedWrite.UPLOADING
 import com.shypolarbear.presentation.ui.join.NAME_RANGE
 import com.shypolarbear.presentation.ui.join.pages.PHONE_NUMBER_DASH_INCLUDE
 import com.shypolarbear.presentation.util.GlideUtil
+import com.shypolarbear.presentation.util.ImageUtil
 import com.shypolarbear.presentation.util.InputState
 import com.shypolarbear.presentation.util.afterTextChanged
 import com.shypolarbear.presentation.util.convertUriToFile
@@ -40,6 +41,7 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
     private var nameState: InputState = InputState.OFF
     private var phoneNumberState: InputState = InputState.OFF
     private var emailState: InputState = InputState.OFF
+    private val imageUtil = ImageUtil
     private lateinit var profileImageUri: Uri
 
     private val pickMedia =
@@ -95,7 +97,8 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                     }
 
                     else -> {
-                        val imageFileList: File = profileImageUri.convertUriToFile(requireContext())
+                        val imageFileList: File? = uploadImage()
+
                         viewModel.requestChangeMyInfo(
                             nickName = edtChangeMyInfoNickname.text.toString(),
                             phoneNumber = edtChangeMyInfoPhoneNumber.text.toString(),
@@ -233,4 +236,6 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
             }
         }
     }
+
+    private fun uploadImage(): File? { return imageUtil.uriToOptimizeImageFile(requireContext(), profileImageUri) }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -53,6 +53,9 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
     override fun initView() {
 
         binding.apply {
+            progressChangeMyInfoLoading.isVisible = true
+            layoutChangeMyInfo.isVisible = false
+
             viewModel.getMyInfo()
             viewModel.myInfo.observe(viewLifecycleOwner) { info ->
                 edtChangeMyInfoNickname.setText(info.nickName)
@@ -65,6 +68,9 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                 } else {
                     GlideUtil.loadImage(requireContext(), url = null, view = binding.ivChangeMyInfoProfile, placeHolder = R.drawable.ic_user_base_profile)
                 }
+
+                progressChangeMyInfoLoading.isVisible = false
+                layoutChangeMyInfo.isVisible = true
             }
 
             btnChangeMyInfoBack.setOnClickListener {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoFragment.kt
@@ -1,9 +1,13 @@
 package com.shypolarbear.presentation.ui.more.changemyinfo
 
+import android.net.Uri
 import android.telephony.PhoneNumberFormattingTextWatcher
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.Toast
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -11,15 +15,20 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.shypolarbear.presentation.R
 import com.shypolarbear.presentation.base.BaseFragment
 import com.shypolarbear.presentation.databinding.FragmentChangeMyInfoBinding
+import com.shypolarbear.presentation.ui.feed.feedWrite.UPLOADED
+import com.shypolarbear.presentation.ui.feed.feedWrite.UPLOADING
 import com.shypolarbear.presentation.ui.join.NAME_RANGE
 import com.shypolarbear.presentation.ui.join.pages.PHONE_NUMBER_DASH_INCLUDE
+import com.shypolarbear.presentation.util.GlideUtil
 import com.shypolarbear.presentation.util.InputState
 import com.shypolarbear.presentation.util.afterTextChanged
+import com.shypolarbear.presentation.util.convertUriToFile
 import com.shypolarbear.presentation.util.emailPattern
 import com.shypolarbear.presentation.util.keyboardDown
 import com.shypolarbear.presentation.util.phonePattern
 import com.shypolarbear.presentation.util.setColorStateWithInput
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.File
 
 @AndroidEntryPoint
 class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyInfoViewModel> (
@@ -31,6 +40,13 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
     private var nameState: InputState = InputState.OFF
     private var phoneNumberState: InputState = InputState.OFF
     private var emailState: InputState = InputState.OFF
+    private lateinit var profileImageUri: Uri
+
+    private val pickMedia =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            uri?.let { profileImageUri = uri }
+
+        }
 
     override fun initView() {
 
@@ -40,10 +56,21 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                 edtChangeMyInfoNickname.setText(info.nickName)
                 edtChangeMyInfoPhoneNumber.setText(info.phoneNumber)
                 edtChangeMyInfoEmail.setText(info.email)
+                profileImageUri = info.profileImage.toUri()
+
+                if (!info.profileImage.isNullOrBlank()) {
+                    GlideUtil.loadImage(requireContext(), info.profileImage, binding.ivChangeMyInfoProfile)
+                } else {
+                    GlideUtil.loadImage(requireContext(), url = null, view = binding.ivChangeMyInfoProfile, placeHolder = R.drawable.ic_user_base_profile)
+                }
             }
 
             btnChangeMyInfoBack.setOnClickListener {
                 findNavController().popBackStack()
+            }
+
+            btnChangeMyInfoImgEdit.setOnClickListener {
+                pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             }
 
             btnChangeMyInfoRevise.setOnClickListener {
@@ -60,14 +87,23 @@ class ChangeMyInfoFragment: BaseFragment<FragmentChangeMyInfoBinding, ChangeMyIn
                     }
 
                     else -> {
+                        val imageFileList: File = profileImageUri.convertUriToFile(requireContext())
                         viewModel.requestChangeMyInfo(
                             nickName = edtChangeMyInfoNickname.text.toString(),
                             phoneNumber = edtChangeMyInfoPhoneNumber.text.toString(),
                             email = edtChangeMyInfoEmail.text.toString(),
-                            profileImage = null
+                            profileImageFile = imageFileList
                         )
-                        Toast.makeText(requireContext(), getString(R.string.check_my_info_success), Toast.LENGTH_SHORT).show()
-                        findNavController().popBackStack()
+                    }
+                }
+
+                viewModel.uploadState.observe(viewLifecycleOwner) {
+                    when(viewModel.uploadState.value) {
+                        UPLOADING -> { }
+                        UPLOADED -> {
+                            Toast.makeText(requireContext(), getString(R.string.check_my_info_success), Toast.LENGTH_SHORT).show()
+                            findNavController().popBackStack()
+                        }
                     }
                 }
             }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
@@ -48,19 +48,33 @@ class ChangeMyInfoViewModel @Inject constructor(
         nickName: String,
         email: String,
         phoneNumber: String,
-        profileImageFile: File
+        profileImageFile: File?
     ) {
         viewModelScope.launch {
-            val uploadImages = imageUploadUseCase(ImageUploadRequest(ImageType.PROFILE.type, listOf(profileImageFile)))
-
-            uploadImages
-                .onSuccess {
-                    changeMyInfoUseCase(nickName, it.data.imageLinks[0], email, phoneNumber)
-                    _uploadState.value = UPLOADED
+            // 프로필 사진 없는 경우
+            when(profileImageFile) {
+                null -> {
+                    changeMyInfoUseCase(
+                        nickName = nickName,
+                        profileImage = null,
+                        email = email,
+                        phoneNumber = phoneNumber
+                    )
                 }
-                .onFailure {
+                // 프로필 사진 있는 경우
+                else -> {
+                    val uploadImages = imageUploadUseCase(ImageUploadRequest(ImageType.PROFILE.type, listOf(profileImageFile)))
 
+                    uploadImages
+                        .onSuccess {
+                            changeMyInfoUseCase(nickName, it.data.imageLinks[0], email, phoneNumber)
+                            _uploadState.value = UPLOADED
+                        }
+                        .onFailure {
+
+                        }
                 }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
@@ -26,9 +26,6 @@ class ChangeMyInfoViewModel @Inject constructor(
     private val _myInfo = MutableLiveData<Info>()
     val myInfo: LiveData<Info> = _myInfo
 
-    private val _uploadImageList = MutableLiveData<List<String>>(listOf())
-    val uploadImageList: LiveData<List<String>> = _uploadImageList
-
     private val _uploadState = MutableLiveData(UPLOADING)
     val uploadState: LiveData<Int> = _uploadState
 
@@ -47,26 +44,6 @@ class ChangeMyInfoViewModel @Inject constructor(
         }
     }
 
-//    fun requestChangeMyInfo(
-//        nickName: String,
-//        profileImage: String?,
-//        email: String,
-//        phoneNumber: String
-//    ) {
-//        viewModelScope.launch {
-//            val response = changeMyInfoUseCase(nickName, profileImage, email, phoneNumber)
-//
-//            response
-//                .onSuccess {
-//                    _myInfo.value = it.data
-//                }
-//                .onFailure {
-//
-//                }
-//
-//        }
-//    }
-
     fun requestChangeMyInfo(
         nickName: String,
         email: String,
@@ -78,9 +55,7 @@ class ChangeMyInfoViewModel @Inject constructor(
 
             uploadImages
                 .onSuccess {
-                    _uploadImageList.value = it.data.imageLinks
-                    changeMyInfoUseCase(nickName, _uploadImageList.value!![0], email, phoneNumber)
-
+                    changeMyInfoUseCase(nickName, it.data.imageLinks[0], email, phoneNumber)
                     _uploadState.value = UPLOADED
                 }
                 .onFailure {

--- a/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/ui/more/changemyinfo/ChangeMyInfoViewModel.kt
@@ -3,21 +3,34 @@ package com.shypolarbear.presentation.ui.more.changemyinfo
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import com.shypolarbear.domain.model.image.ImageUploadRequest
 import com.shypolarbear.domain.model.more.Info
+import com.shypolarbear.domain.usecase.image.RequestImageUploadUseCase
 import com.shypolarbear.domain.usecase.more.RequestMyInfoChangeUseCase
 import com.shypolarbear.domain.usecase.more.LoadMyInfoUseCase
 import com.shypolarbear.presentation.base.BaseViewModel
+import com.shypolarbear.presentation.ui.feed.feedWrite.UPLOADED
+import com.shypolarbear.presentation.ui.feed.feedWrite.UPLOADING
+import com.shypolarbear.presentation.util.ImageType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
 class ChangeMyInfoViewModel @Inject constructor(
     private val getMyInfoUseCase: LoadMyInfoUseCase,
-    private val changeMyInfoUseCase: RequestMyInfoChangeUseCase
+    private val changeMyInfoUseCase: RequestMyInfoChangeUseCase,
+    private val imageUploadUseCase: RequestImageUploadUseCase
 ): BaseViewModel() {
     private val _myInfo = MutableLiveData<Info>()
     val myInfo: LiveData<Info> = _myInfo
+
+    private val _uploadImageList = MutableLiveData<List<String>>(listOf())
+    val uploadImageList: LiveData<List<String>> = _uploadImageList
+
+    private val _uploadState = MutableLiveData(UPLOADING)
+    val uploadState: LiveData<Int> = _uploadState
 
     fun getMyInfo() {
         viewModelScope.launch {
@@ -34,23 +47,45 @@ class ChangeMyInfoViewModel @Inject constructor(
         }
     }
 
+//    fun requestChangeMyInfo(
+//        nickName: String,
+//        profileImage: String?,
+//        email: String,
+//        phoneNumber: String
+//    ) {
+//        viewModelScope.launch {
+//            val response = changeMyInfoUseCase(nickName, profileImage, email, phoneNumber)
+//
+//            response
+//                .onSuccess {
+//                    _myInfo.value = it.data
+//                }
+//                .onFailure {
+//
+//                }
+//
+//        }
+//    }
+
     fun requestChangeMyInfo(
         nickName: String,
-        profileImage: String?,
         email: String,
-        phoneNumber: String
+        phoneNumber: String,
+        profileImageFile: File
     ) {
         viewModelScope.launch {
-            val response = changeMyInfoUseCase(nickName, profileImage, email, phoneNumber)
+            val uploadImages = imageUploadUseCase(ImageUploadRequest(ImageType.PROFILE.type, listOf(profileImageFile)))
 
-            response
+            uploadImages
                 .onSuccess {
-                    _myInfo.value = it.data
+                    _uploadImageList.value = it.data.imageLinks
+                    changeMyInfoUseCase(nickName, _uploadImageList.value!![0], email, phoneNumber)
+
+                    _uploadState.value = UPLOADED
                 }
                 .onFailure {
 
                 }
-
         }
     }
 }

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
@@ -86,16 +86,12 @@ fun Uri.convertUriToPath(context: Context): String {
 
 fun Uri.convertUriToFile(context: Context): File {
     val proj: Array<String> = arrayOf(MediaStore.Images.Media.DATA)
-    Timber.d("$proj")
     val cursor = context.contentResolver.query(this, proj, null, null, null)
     val index = cursor?.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
-    Timber.d("$index")
     cursor?.moveToFirst()
-    Timber.d("$cursor")
     val path = cursor?.getString(index!!)
     cursor?.close()
 
-    Timber.d("$path")
     return File(path!!)
 }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/FunctionUtil.kt
@@ -86,12 +86,16 @@ fun Uri.convertUriToPath(context: Context): String {
 
 fun Uri.convertUriToFile(context: Context): File {
     val proj: Array<String> = arrayOf(MediaStore.Images.Media.DATA)
+    Timber.d("$proj")
     val cursor = context.contentResolver.query(this, proj, null, null, null)
     val index = cursor?.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+    Timber.d("$index")
     cursor?.moveToFirst()
+    Timber.d("$cursor")
     val path = cursor?.getString(index!!)
     cursor?.close()
 
+    Timber.d("$path")
     return File(path!!)
 }
 

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/GlideUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/GlideUtil.kt
@@ -34,6 +34,10 @@ object GlideUtil {
         loadGlide(context, uri = uri).centerCrop().circleCrop().into(view)
     }
 
+    fun loadCircleImage(context: Context, url: String?, view: ImageView, placeHolder: Int) {
+        loadGlide(context, url = url).centerCrop().circleCrop().placeholder(placeHolder).into(view)
+    }
+
     private fun loadGlide(context: Context, url: String? = null) = run {
         Glide.with(context).load(url)
     }

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/ImageUtil.kt
@@ -31,14 +31,12 @@ object ImageUtil{
             val fos = FileOutputStream(tempFile)
 
             decodeOptimizeBitmapFromUri(context, uri)?.apply {
-                compress(Bitmap.CompressFormat.JPEG, 100, fos)
+                compress(Bitmap.CompressFormat.JPEG, 90, fos)
                 recycle()
             } ?: throw NullPointerException()
 
             fos.flush()
             fos.close()
-
-            Timber.d("압축된 파일 크기: ${tempFile.length()/ (1024.0 * 1024.0)}MB")
 
             return tempFile
         } catch (e: Exception) {

--- a/presentation/src/main/java/com/shypolarbear/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/shypolarbear/presentation/util/ImageUtil.kt
@@ -1,0 +1,144 @@
+package com.shypolarbear.presentation.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
+import android.net.Uri
+import timber.log.Timber
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+object ImageUtil{
+
+    private const val MAX_IMAGE_WIDTH = 1440
+    private const val MAX_IMAGE_HEIGHT = 1440
+
+//    이미지 최대 사이즈 : 1440 * 1440
+//    이미지 최대 용량 : 1440 * 1440 / 1024 / 1024 = 7.91MB로 이미지 최적화한다.
+
+    fun uriToOptimizeImageFile(context: Context, uri: Uri): File? {
+        try {
+            val storage = context.cacheDir
+            val fileName = String.format("%s.%s", UUID.randomUUID(), "jpg")
+
+            val tempFile = File(storage, fileName)
+            tempFile.createNewFile()
+
+            val fos = FileOutputStream(tempFile)
+
+            decodeOptimizeBitmapFromUri(context, uri)?.apply {
+                compress(Bitmap.CompressFormat.JPEG, 100, fos)
+                recycle()
+            } ?: throw NullPointerException()
+
+            fos.flush()
+            fos.close()
+
+            Timber.d("압축된 파일 크기: ${tempFile.length()/ (1024.0 * 1024.0)}MB")
+
+            return tempFile
+        } catch (e: Exception) {
+            Timber.e("${e.message}")
+        }
+
+        return null
+    }
+
+//    BitmapFactory를 사용하게 되면 Bitmap.Config는 기본으로 ARGB_8888으로 설정된다.
+//    이미지의 최대 가로/세로 길이가 1280이라고 할 때,
+//    Bitmap의 최대 크기는 1280 * 1280 * 4 = 6.25MB가 된다.
+//    즉 해당 함수는 Bitmap을 6.25MB 이하로 만들어준다.
+
+    private fun decodeOptimizeBitmapFromUri(context: Context, uri: Uri): Bitmap? {
+        val input = BufferedInputStream(context.contentResolver.openInputStream(uri))
+
+        input.mark(input.available())
+
+        var bitmap: Bitmap?
+
+        BitmapFactory.Options().run {
+            inJustDecodeBounds = true
+            bitmap = BitmapFactory.decodeStream(input, null, this)
+
+            input.reset()
+
+            inSampleSize = calculateInSampleSize(this)
+            inJustDecodeBounds = false
+
+            bitmap = rotateImageIfRequired(context, BitmapFactory.decodeStream(input, null, this)!!, uri)
+        }
+
+        input.close()
+
+        return bitmap
+    }
+
+    private fun calculateInSampleSize(options: BitmapFactory.Options): Int {
+        val (height: Int, width: Int) = options.run { outHeight to outWidth }
+        var inSampleSize = 1
+
+        if (height > MAX_IMAGE_HEIGHT || width > MAX_IMAGE_WIDTH) {
+            val halfHeight: Int = height / 2
+            val halfWidth: Int = width / 2
+
+            while (halfHeight / inSampleSize >= MAX_IMAGE_HEIGHT && halfWidth / inSampleSize >= MAX_IMAGE_WIDTH) {
+                inSampleSize *= 2
+            }
+        }
+
+        return inSampleSize
+    }
+
+    private fun rotateImageIfRequired(context: Context, bitmap: Bitmap, uri: Uri): Bitmap? {
+        val input = context.contentResolver.openInputStream(uri) ?: return null
+
+        val exif =
+            ExifInterface(input)
+
+        val orientation =
+            exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+
+        return rotateBitmap(bitmap, orientation)
+    }
+
+    private fun rotateBitmap(bitmap: Bitmap, orientation: Int): Bitmap? {
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_NORMAL -> return bitmap
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.setScale(-1f, 1f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(180f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+                matrix.setRotate(180f)
+                matrix.postScale(-1f, 1f)
+            }
+
+            ExifInterface.ORIENTATION_TRANSPOSE -> {
+                matrix.setRotate(90f)
+                matrix.postScale(-1f, 1f)
+            }
+
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.setRotate(90f)
+            ExifInterface.ORIENTATION_TRANSVERSE -> {
+                matrix.setRotate(-90f)
+                matrix.postScale(-1f, 1f)
+            }
+
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(-90f)
+            else -> return bitmap
+        }
+
+        return try {
+            val bmRotated =
+                Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+            bitmap.recycle()
+            bmRotated
+        } catch (e: OutOfMemoryError) {
+            e.printStackTrace()
+            null
+        }
+    }
+}

--- a/presentation/src/main/res/layout/fragment_change_my_info.xml
+++ b/presentation/src/main/res/layout/fragment_change_my_info.xml
@@ -11,205 +11,225 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_change_my_info_back"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="16dp"
-            android:background="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/iv_change_my_info_profile"
-            android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:layout_marginTop="32dp"
-            android:contentDescription="@string/profile_icon"
-            android:src="@drawable/ic_user_base_profile"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_change_my_info_back" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_change_my_info_img_edit"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
-            android:background="@drawable/ic_signup_name_edit"
-            app:layout_constraintBottom_toBottomOf="@id/iv_change_my_info_profile"
-            app:layout_constraintEnd_toEndOf="@+id/iv_change_my_info_profile" />
-
-        <EditText
-            android:id="@+id/edt_change_my_info_nickname"
-            style="@style/b1"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="40dp"
-            android:layout_marginEnd="20dp"
-            android:background="@drawable/selector_signup_nickname"
-            android:hint="@string/hint_signup_nickname"
-            android:inputType="text"
-            android:padding="10dp"
-            android:textColorHint="@color/Gray_05"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_change_my_info_profile" />
-
-        <ImageView
-            android:id="@+id/iv_change_my_info_name_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:src="@drawable/ic_signup_success"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_nickname"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_nickname"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_nickname" />
-
-        <ProgressBar
-            android:id="@+id/pg_change_my_info_name_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:indeterminateTint="@color/Blue_02"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_nickname"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_nickname"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_nickname" />
-
-        <TextView
-            android:id="@+id/tv_change_my_info_name_rule"
-            style="@style/l2"
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_change_my_info_loading"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:text="@string/signup_name_rule"
-            android:textColor="@color/selector_signup_name_text_color"
-            app:layout_constraintStart_toStartOf="@id/edt_change_my_info_nickname"
-            app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_nickname" />
-
-        <EditText
-            android:id="@+id/edt_change_my_info_phone_number"
-            style="@style/b1"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="24dp"
-            android:layout_marginEnd="20dp"
-            android:background="@drawable/selector_signup_nickname"
-            android:hint="@string/signup_phone_hint"
-            android:inputType="phone"
-            android:padding="10dp"
-            android:textColorHint="@color/Gray_05"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_change_my_info_name_rule" />
-
-        <ImageView
-            android:id="@+id/iv_change_my_info_phone_number_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:src="@drawable/ic_signup_success"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_phone_number"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_phone_number"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_phone_number" />
-
-        <ProgressBar
-            android:id="@+id/pg_change_my_info_phone_number_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:indeterminateTint="@color/Blue_02"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_phone_number"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_phone_number"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_phone_number" />
-
-        <TextView
-            android:id="@+id/tv_change_my_info_phone_number_rule"
-            style="@style/l2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:text="@string/signup_phone_hint_detail"
-            android:textColor="@color/selector_signup_name_text_color"
-            app:layout_constraintStart_toStartOf="@id/edt_change_my_info_phone_number"
-            app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_phone_number" />
-
-        <EditText
-            android:id="@+id/edt_change_my_info_email"
-            style="@style/b1"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="24dp"
-            android:layout_marginEnd="20dp"
-            android:background="@drawable/selector_signup_nickname"
-            android:hint="@string/signup_mail_hint"
-            android:inputType="textEmailAddress"
-            android:padding="10dp"
-            android:textColorHint="@color/Gray_05"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_change_my_info_phone_number_rule" />
-
-        <ImageView
-            android:id="@+id/iv_change_my_info_email_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:src="@drawable/ic_signup_success"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_email"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_email"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_email" />
-
-        <ProgressBar
-            android:id="@+id/pg_change_my_info_email_check"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="12dp"
-            android:layout_marginEnd="10dp"
-            android:indeterminateTint="@color/Blue_02"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_email"
-            app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_email"
-            app:layout_constraintTop_toTopOf="@id/edt_change_my_info_email" />
-
-        <TextView
-            android:id="@+id/tv_change_my_info_email_rule"
-            style="@style/l2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:textColor="@color/selector_signup_name_text_color"
-            app:layout_constraintStart_toStartOf="@id/edt_change_my_info_email"
-            app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_email"
-            tools:text="Email 힌트" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_change_my_info_revise"
-            style="@style/Button1"
-            android:layout_width="match_parent"
-            android:layout_height="60dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginBottom="40dp"
-            android:background="@drawable/background_solid_blue_01_radius_15"
-            android:text="@string/more_change_my_info_complete"
-            android:textColor="@color/White_01"
+            android:indeterminate="true"
+            app:indicatorColor="@color/Blue_02"
+            app:indicatorSize="36dp"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:trackThickness="5dp" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_change_my_info"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_change_my_info_back"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/ic_back"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/iv_change_my_info_profile"
+                android:layout_width="120dp"
+                android:layout_height="120dp"
+                android:layout_marginTop="32dp"
+                android:contentDescription="@string/profile_icon"
+                android:src="@drawable/ic_user_base_profile"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btn_change_my_info_back" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_change_my_info_img_edit"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:background="@drawable/ic_signup_name_edit"
+                app:layout_constraintBottom_toBottomOf="@id/iv_change_my_info_profile"
+                app:layout_constraintEnd_toEndOf="@+id/iv_change_my_info_profile" />
+
+            <EditText
+                android:id="@+id/edt_change_my_info_nickname"
+                style="@style/b1"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="40dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/selector_signup_nickname"
+                android:hint="@string/hint_signup_nickname"
+                android:inputType="text"
+                android:padding="10dp"
+                android:textColorHint="@color/Gray_05"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_change_my_info_profile" />
+
+            <ImageView
+                android:id="@+id/iv_change_my_info_name_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:src="@drawable/ic_signup_success"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_nickname"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_nickname"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_nickname" />
+
+            <ProgressBar
+                android:id="@+id/pg_change_my_info_name_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:indeterminateTint="@color/Blue_02"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_nickname"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_nickname"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_nickname" />
+
+            <TextView
+                android:id="@+id/tv_change_my_info_name_rule"
+                style="@style/l2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/signup_name_rule"
+                android:textColor="@color/selector_signup_name_text_color"
+                app:layout_constraintStart_toStartOf="@id/edt_change_my_info_nickname"
+                app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_nickname" />
+
+            <EditText
+                android:id="@+id/edt_change_my_info_phone_number"
+                style="@style/b1"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/selector_signup_nickname"
+                android:hint="@string/signup_phone_hint"
+                android:inputType="phone"
+                android:padding="10dp"
+                android:textColorHint="@color/Gray_05"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_change_my_info_name_rule" />
+
+            <ImageView
+                android:id="@+id/iv_change_my_info_phone_number_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:src="@drawable/ic_signup_success"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_phone_number"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_phone_number"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_phone_number" />
+
+            <ProgressBar
+                android:id="@+id/pg_change_my_info_phone_number_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:indeterminateTint="@color/Blue_02"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_phone_number"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_phone_number"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_phone_number" />
+
+            <TextView
+                android:id="@+id/tv_change_my_info_phone_number_rule"
+                style="@style/l2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/signup_phone_hint_detail"
+                android:textColor="@color/selector_signup_name_text_color"
+                app:layout_constraintStart_toStartOf="@id/edt_change_my_info_phone_number"
+                app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_phone_number" />
+
+            <EditText
+                android:id="@+id/edt_change_my_info_email"
+                style="@style/b1"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/selector_signup_nickname"
+                android:hint="@string/signup_mail_hint"
+                android:inputType="textEmailAddress"
+                android:padding="10dp"
+                android:textColorHint="@color/Gray_05"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_change_my_info_phone_number_rule" />
+
+            <ImageView
+                android:id="@+id/iv_change_my_info_email_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:src="@drawable/ic_signup_success"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_email"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_email"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_email" />
+
+            <ProgressBar
+                android:id="@+id/pg_change_my_info_email_check"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="12dp"
+                android:layout_marginEnd="10dp"
+                android:indeterminateTint="@color/Blue_02"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="@id/edt_change_my_info_email"
+                app:layout_constraintEnd_toEndOf="@id/edt_change_my_info_email"
+                app:layout_constraintTop_toTopOf="@id/edt_change_my_info_email" />
+
+            <TextView
+                android:id="@+id/tv_change_my_info_email_rule"
+                style="@style/l2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:textColor="@color/selector_signup_name_text_color"
+                app:layout_constraintStart_toStartOf="@id/edt_change_my_info_email"
+                app:layout_constraintTop_toBottomOf="@+id/edt_change_my_info_email"
+                tools:text="Email 힌트" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_change_my_info_revise"
+                style="@style/Button1"
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="40dp"
+                android:background="@drawable/background_solid_blue_01_radius_15"
+                android:text="@string/more_change_my_info_complete"
+                android:textColor="@color/White_01"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/fragment_change_my_info.xml
+++ b/presentation/src/main/res/layout/fragment_change_my_info.xml
@@ -39,7 +39,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
+            <com.google.android.material.imageview.ShapeableImageView
                 android:id="@+id/iv_change_my_info_profile"
                 android:layout_width="120dp"
                 android:layout_height="120dp"
@@ -48,7 +48,8 @@
                 android:src="@drawable/ic_user_base_profile"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/btn_change_my_info_back" />
+                app:layout_constraintTop_toBottomOf="@id/btn_change_my_info_back"
+                app:shapeAppearanceOverlay="@style/radius_24"/>
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_change_my_info_img_edit"


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 피드, 내 정보 조회, 내 정보 수정에서 이미지 api 연동

🌱 PR 포인트
- 이미지 업로드 동작이 다른 작업들에 비해 시간이 걸리기 때문에 viewModel에서 이미지 업로드 유즈케이스를 사용하여 업로드를 진행한 후 성공한 경우 링크와 함께 작성/수정 요청을 보내도록 하였습니다. 그리고 이미지와 게시물이 모두 완료되면 업로드 상태를 담는 라이브 데이터에 값을 변경하고 이를 프래그먼트에서 관찰하다가 업로드가 되었을 때의 값이 되면 이전 화면으로 돌아가도록 처리하였습니다.

- 피드 수정 시 이미지 수정 로직
  기존의 이미지 리스트와 수정하고자 하는 이미지 리스트를 비교하여 추가되었다고 판단되는 uri들을 업로드하여 링크를 받아서 남아있는 이미지 리스트에 더해서 수정하도록 하였습니다.
  (복잡해서 코드에 주석으로 설명을 해놨습니다. 주석은 필요에 따라 merge 전에 지울지 말지 결정할 예정)

- 이미지 업로드 시 이미지 리스트의 최대 용량이 10MB이므로 업로드 전 리사이징 하는 동작을 추가하였습니다. 
**21.3MB 이미지 기준**

```
80% -> 0.9772272109985352MB (약 1MB)
90% -> 1.521270751953125MB (약 2MB)
100% -> 4.516690254211426MB (약 5MB)
```

위와 같은 용량으로 압축되는 것을 확인 하였고 **5개의 이미지를 전송할 때 90%로 압축하는 것이 10MB를 넘지 않고 가장 좋은 화질을 유지**할 수 있다고 생각되서 90%로 압축하도록 하였습니다.

## 📸 스크린샷
|스크린샷|
https://github.com/ShyPolarBear/Android/assets/107917980/0962f630-89cf-4391-9cd7-fa8e8f935a25

## 📮 관련 이슈
- Resolved: #70 
