### PR TITLE
[WBS-242]design: Quiz 화면에서 하단 부 여백 나오는 방식 조정

### DIFF
--- a/presentation/src/main/res/layout/fragment_quiz_main.xml
+++ b/presentation/src/main/res/layout/fragment_quiz_main.xml
@@ -115,10 +115,9 @@
             android:id="@+id/quiz_main_rv"
             android:layout_width="0dp"
             android:foregroundGravity="center_vertical"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:orientation="horizontal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toTopOf="@+id/quiz_main_box_bottom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/quiz_main_tv_recent" />
@@ -129,7 +128,7 @@
             android:layout_height="10dp"
             android:layout_marginBottom="16dp"
             android:background="#F2FAFF"
-            app:layout_constraintBottom_toTopOf="@id/quiz_main_tv_detail"
+            app:layout_constraintTop_toBottomOf="@+id/quiz_main_rv"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
@@ -138,9 +137,9 @@
             style="@style/H5"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="12dp"
+            android:layout_marginTop="16dp"
             android:text="@string/quiz_main_write_detail"
-            app:layout_constraintBottom_toTopOf="@id/quiz_main_btn_write"
+            app:layout_constraintTop_toBottomOf="@+id/quiz_main_box_bottom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
@@ -148,11 +147,12 @@
             android:id="@+id/quiz_main_btn_write"
             android:layout_width="0dp"
             android:layout_height="60dp"
+            android:layout_marginTop="12dp"
             android:layout_marginHorizontal="20dp"
             android:layout_marginBottom="116dp"
             android:background="@drawable/ripple_btn"
             android:clickable="true"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/quiz_main_tv_detail"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 

--- a/presentation/src/main/res/layout/item_quiz_main_recent_feed.xml
+++ b/presentation/src/main/res/layout/item_quiz_main_recent_feed.xml
@@ -18,6 +18,7 @@
             android:id="@+id/item_quiz_main_cv"
             android:layout_width="160dp"
             android:layout_height="140dp"
+            app:cardElevation="0dp"
             app:cardCornerRadius="5dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Quiz 화면에서 하단 부 여백 나오는 방식 조정

🌱 PR 포인트
- 하단부 여백이 bottom 고정이 아니라 상단 아이템에 딸려서 올라가게 xml 수정했습니다
- Recyclerview 아이템에 그림자도 같이 지웠습니다.

## 📸 스크린샷
|스크린샷|
|:-
![Screenshot_1698853918](https://github.com/ShyPolarBear/Android/assets/46841652/562bcc71-2fb1-4cdd-9942-83d4d328d9e4)
-:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #85 